### PR TITLE
Support for self-signed certificates

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromAuthServer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromAuthServer.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.pid
 
 import eu.europa.ec.eudi.pidissuer.adapter.out.oauth.OidcAddressClaim
 import eu.europa.ec.eudi.pidissuer.adapter.out.oauth.OidcAssurancePlaceOfBirth
+import eu.europa.ec.eudi.pidissuer.adapter.out.webclient.WebClients
 import eu.europa.ec.eudi.pidissuer.domain.HttpsUrl
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -32,17 +33,15 @@ import java.time.LocalDate
 
 private val log = LoggerFactory.getLogger(GetPidDataFromAuthServer::class.java)
 
-class GetPidDataFromAuthServer(
-    authorizationServerUserInfoEndPoint: HttpsUrl,
+class GetPidDataFromAuthServer private constructor(
     private val issuerCountry: IsoCountry,
     private val clock: Clock,
+    private val webClient: WebClient,
 ) : GetPidData {
 
     private val jsonSupport: Json by lazy {
         Json { prettyPrint = true }
     }
-    private val webClient: WebClient =
-        WebClient.create(authorizationServerUserInfoEndPoint.externalForm)
 
     override suspend fun invoke(accessToken: String): Pair<Pid, PidMetaData>? {
         log.info("Trying to get PID Data from userinfo endpoint ...")
@@ -94,6 +93,42 @@ class GetPidDataFromAuthServer(
 
         return pid to pidMetaData
     }
+
+    companion object {
+
+        /**
+         * Creates a new [GetPidDataFromAuthServer] using the provided data.
+         */
+        operator fun invoke(
+            authorizationServerUserInfoEndPoint: HttpsUrl,
+            issuerCountry: IsoCountry,
+            clock: Clock,
+        ): GetPidDataFromAuthServer =
+            GetPidDataFromAuthServer(
+                issuerCountry,
+                clock,
+                WebClients.default {
+                    baseUrl(authorizationServerUserInfoEndPoint.externalForm)
+                },
+            )
+
+        /**
+         * Creates a new *insecure* [GetPidDataFromAuthServer] that trusts all certificates.
+         */
+        fun insecure(
+            authorizationServerUserInfoEndPoint: HttpsUrl,
+            issuerCountry: IsoCountry,
+            clock: Clock,
+        ): GetPidDataFromAuthServer {
+            return GetPidDataFromAuthServer(
+                issuerCountry,
+                clock,
+                WebClients.insecure {
+                    baseUrl(authorizationServerUserInfoEndPoint.externalForm)
+                },
+            )
+        }
+    }
 }
 
 @Serializable
@@ -105,7 +140,7 @@ private data class UserInfo(
     @SerialName(OidcAddressClaim.NAME) val address: OidcAddressClaim? = null,
     @SerialName("birthdate") val birthDate: String? = null,
     @SerialName("gender") val gender: UInt? = null,
-    @SerialName(OidcAssurancePlaceOfBirth.NAME)val placeOfBirth: OidcAssurancePlaceOfBirth? = null,
+    @SerialName(OidcAssurancePlaceOfBirth.NAME) val placeOfBirth: OidcAssurancePlaceOfBirth? = null,
     @SerialName("age_over_18") val ageOver18: Boolean? = null,
     val profile: String? = null,
     val picture: String? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/webclient/WebClients.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/webclient/WebClients.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.pidissuer.adapter.out.webclient
+
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import org.slf4j.LoggerFactory
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+
+private val log = LoggerFactory.getLogger(WebClients::class.java)
+
+/**
+ * Factories for [WebClient].
+ */
+internal object WebClients {
+
+    /**
+     * Creates a new [WebClient].
+     */
+    fun default(customizer: WebClient.Builder.() -> Unit = {}): WebClient =
+        WebClient.builder()
+            .apply(customizer)
+            .build()
+
+    /**
+     * Creates an *insecure* [WebClient] that trusts all certificates.
+     */
+    fun insecure(customizer: WebClient.Builder.() -> Unit = {}): WebClient {
+        log.warn("Using insecure WebClient trusting all certificates")
+        val sslContext = SslContextBuilder.forClient()
+            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+            .build()
+        val httpClient = HttpClient.create().secure { it.sslContext(sslContext) }
+        return WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .apply(customizer)
+            .build()
+    }
+}


### PR DESCRIPTION
Adds the ability to trust self-signed certificates.

Besides configuring the `WebClient` in `GetPidDataFromAuthServer` we also need to configure a `SpringReactiveOpaqueTokenIntrospector` with a `WebClient` that trusts self-signed certificates.

This functionality is opt-in and disabled by default. To trust self-signed certificates the `insecure` Spring Profile must be activated.