### PR TITLE
Require PKCE and PAR for wallet-dev OIDC client.

### DIFF
--- a/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
+++ b/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
@@ -999,7 +999,9 @@
         "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "false",
         "display.on.consent.screen": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "require.pushed.authorization.requests": "true",
+        "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,


### PR DESCRIPTION
Closes #35 