### PR TITLE
Remove snapshot repo from gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,6 @@ version = "0.2.0-SNAPSHOT"
 repositories {
     mavenCentral()
     maven {
-        url = URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        this.mavenContent {
-            snapshotsOnly()
-        }
-    }
-    maven {
         url = URI.create("https://jitpack.io")
     }
 }


### PR DESCRIPTION
After publication there is no good reason to have SNAPSHOT dependencies repository enabled.
Application can use stable releases of EUDIW libs.

This PR removes the snapshot repository from gradle
