### PR TITLE
Updated credential offer URI creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,9 +16,6 @@ plugins {
     jacoco
 }
 
-group = "eu.europa.ec.eudi"
-version = "0.2.0-SNAPSHOT"
-
 repositories {
     mavenCentral()
     maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024m
 
+group=eu.europa.ec.eudi
+version=0.2.0-SNAPSHOT
+
 # Sonar
 systemProp.sonar.gradle.skipCompile=true
 systemProp.sonar.host.url=https://sonarcloud.io

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -70,7 +70,6 @@ import org.springframework.security.web.server.authentication.HttpStatusServerEn
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.netty.http.client.HttpClient
-import java.net.URI
 import java.time.Clock
 import java.time.Duration
 
@@ -313,7 +312,7 @@ fun beans(clock: Clock) = beans {
     }
     bean(::GetDeferredCredential)
     bean {
-        CreateCredentialsOffer(ref(), env.getRequiredProperty<URI>("issuer.credentialOffer.uri"))
+        CreateCredentialsOffer(ref(), env.getRequiredProperty<String>("issuer.credentialOffer.uri"))
     }
 
     //

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/CreateCredentialsOffer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/CreateCredentialsOffer.kt
@@ -108,7 +108,7 @@ private data class CredentialsOfferTO(
  */
 class CreateCredentialsOffer(
     private val metadata: CredentialIssuerMetaData,
-    private val credentialsOfferUri: URI,
+    private val credentialsOfferUri: String,
 ) {
 
     context(Raise<CreateCredentialsOfferError>)
@@ -118,7 +118,7 @@ class CreateCredentialsOffer(
             authorizationCodeGrantOffer(credentialConfigurationIds)
         }
 
-        return UriComponentsBuilder.fromUri(credentialsOfferUri)
+        return UriComponentsBuilder.fromUriString(credentialsOfferUri)
             .queryParam("credential_offer", Json.encodeToString(offer))
             .build()
             .toUri()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,7 +34,7 @@ issuer.pid.issuingCountry=FC
 issuer.mdl.enabled=true
 issuer.mdl.mso_mdoc.encoderUrl=https://preprod.issuer.eudiw.dev/formatter/cbor
 issuer.mdl.notifications.enabled=true
-issuer.credentialOffer.uri=eudi-openid4ci://credentialsOffer
+issuer.credentialOffer.uri=eudi-openid4ci://
 
 spring.security.oauth2.resourceserver.opaquetoken.client-id=pid-issuer-srv
 spring.security.oauth2.resourceserver.opaquetoken.client-secret=zIKAV9DIIIaJCzHCVBPlySgU8KgY68U2


### PR DESCRIPTION
This PR

- Moves the version of the project to the `gradle.properties`
- Simplifies the URI of the credential offer 

For the 2nd point, until now application creates credential offers that look like

`eudi-openid4ci://credentialsOffer?credential_offer=...`

The PR simplifies this to

`eudi-openid4ci://?credential_offer=...`