### PR TITLE
Authorization server metadata and DPoP fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,24 +113,26 @@ Variable: `SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_SECRET`
 Description: Client Server of the OAuth2 client registered in the Authorization Server  
 Default value: N/A
 
+Variable: `SERVER_FORWARD_HEADERS_STRATEGY`  
+Description: Whether the server should consider X-Forwarded headers. In case the application is behind a reverse proxy,
+set this to `FRAMEWORK`.  
+Possible values: `FRAMEWORK`, `NONE`  
+Default value: `FRAMEWORK`  
+
 Variable: `ISSUER_PUBLICURL`  
 Description: URL the PID Issuer application is accessible from  
 Default value: `http://localhost:${SERVER_PORT}${SPRING_WEBFLUX_BASE_PATH}`
 
 Variable: `ISSUER_AUTHORIZATIONSERVER_PUBLICURL`  
 Description: URL of the Authorization Server advertised via the issuer metadata    
-Default value: Value of `ISSUER_AUTHORIZATIONSERVER`  
+Default value: N/A  
 
-Variable: `ISSUER_AUTHORIZATIONSERVER`    
-Description: URL of the Authorization Server  
+Variable: `ISSUER_AUTHORIZATIONSERVER_METADATA`  
+Description: URL used to fetch the metadata of the Authorization Server      
 Default value: N/A
 
 Variable: `ISSUER_AUTHORIZATIONSERVER_INTROSPECTION`  
 Description: URL of the Token Introspection endpoint of the Authorization Server  
-Default value: N/A
-
-Variable: `ISSUER_AUTHORIZATIONSERVER_USERINFO`  
-Description: URL of the UserInfo endpoint of the Authorization Server  
 Default value: N/A
 
 Variable: `ISSUER_PID_MSO_MDOC_ENABLED`  

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -52,9 +52,10 @@ services:
       - SPRING_WEBFLUX_BASE_PATH=/pid-issuer
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID=pid-issuer-srv
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_SECRET=zIKAV9DIIIaJCzHCVBPlySgU8KgY68U2
+      - SERVER_FORWARD_HEADERS_STRATEGY=FRAMEWORK
       - ISSUER_PUBLICURL=https://localhost/pid-issuer
       - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://localhost/idp/realms/pid-issuer-realm
-      - ISSUER_AUTHORIZATIONSERVER=https://keycloak:8443/idp/realms/pid-issuer-realm
+      - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/idp/realms/pid-issuer-realm/.well-known/openid-configuration
       - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
       - ISSUER_PID_MSO_MDOC_ENABLED=true
       - ISSUER_PID_SD_JWT_VC_ENABLED=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,7 +1,7 @@
 #
 # Issuer options
 #
-issuer.authorizationServer=https://dev.auth.eudiw.dev/realms/pid-issuer-realm
+issuer.authorizationServer.publicUrl=https://dev.auth.eudiw.dev/realms/pid-issuer-realm
 issuer.pid.mso_mdoc.encoderUrl=https://preprod.issuer.eudiw.dev/formatter/cbor
 issuer.mdl.mso_mdoc.encoderUrl=https://preprod.issuer.eudiw.dev/formatter/cbor
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,14 +9,15 @@ spring.webflux.base-path=/
 spring.webflux.static-path-pattern=/public/**
 spring.webflux.webjars-path-pattern=/webjars/**
 spring.messages.basename=i18n/messages
+server.forward-headers-strategy=framework
 
 #
 # Issuer options
 #
 issuer.publicUrl=http://localhost:${server.port}${spring.webflux.base-path}
-issuer.authorizationServer=https://localhost/idp/realms/pid-issuer-realm
-issuer.authorizationServer.publicUrl=${issuer.authorizationServer}
-issuer.authorizationServer.introspection=${issuer.authorizationServer}/protocol/openid-connect/token/introspect
+issuer.authorizationServer.publicUrl=https://localhost/idp/realms/pid-issuer-realm
+issuer.authorizationServer.metadata=${issuer.authorizationServer.publicUrl}/.well-known/openid-configuration
+issuer.authorizationServer.introspection=${issuer.authorizationServer.publicUrl}/protocol/openid-connect/token/introspect
 issuer.credentialResponseEncryption.supported=true
 issuer.credentialResponseEncryption.required=true
 issuer.credentialResponseEncryption.algorithmsSupported=RSA-OAEP-256

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -26,6 +26,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.token.DPoPAccessToken
 import eu.europa.ec.eudi.pidissuer.PidIssuerApplicationTest
+import eu.europa.ec.eudi.pidissuer.adapter.input.web.security.DPoPConfigurationProperties
 import eu.europa.ec.eudi.pidissuer.adapter.input.web.security.DPoPTokenAuthentication
 import eu.europa.ec.eudi.pidissuer.adapter.out.persistence.InMemoryCNonceRepository
 import eu.europa.ec.eudi.pidissuer.adapter.out.pid.*
@@ -342,6 +343,16 @@ internal class WalletApiTest {
 
     @TestConfiguration
     internal class WalletApiTestConfig {
+
+        @Bean
+        @Primary
+        fun dPoPConfigurationProperties(): DPoPConfigurationProperties =
+            DPoPConfigurationProperties(
+                emptySet(),
+                Duration.ofMinutes(1L),
+                Duration.ofMinutes(10L),
+                null,
+            )
 
         @Bean
         @Primary


### PR DESCRIPTION
1. Introduce a new property to configure the URL to be used to fetch the metadata of the authorization server. This is not necessarily derived from the public URL of the authorization server.
2. Enable parsing of X-Forwarded headers so that the server can successfully determine the currently accessed URI when behind a reverse proxy. When this is not enabled DPoP authentication does not work because `htu` differs from `ServerHttpRequest.uri`.