### PR TITLE
Register a new redirect uri for eudiw and wallet-dev clients.

### DIFF
--- a/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
+++ b/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
@@ -676,7 +676,8 @@
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
         "urn:ietf:wg:oauth:2.0:oob",
-        "eudi-openid4ci://authorize"
+        "eudi-openid4ci://authorize",
+        "eudi-issuance://authorization"
       ],
       "webOrigins": [
         "/*"
@@ -985,7 +986,8 @@
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
         "urn:ietf:wg:oauth:2.0:oob",
-        "eudi-openid4ci://authorize"
+        "eudi-openid4ci://authorize",
+        "eudi-issuance://authorization"
       ],
       "webOrigins": [
         "/*"


### PR DESCRIPTION
Add the new redirect uri `eudi-issuance://authorization` for `eudiw` and `wallet-dev` clients in keycloak.