### PR TITLE
Add previously removed email attribute in registration form. 

### DIFF
--- a/docker-compose/keycloak/themes/pid-issuer/login/register.ftl
+++ b/docker-compose/keycloak/themes/pid-issuer/login/register.ftl
@@ -1,6 +1,6 @@
 <#import "template.ftl" as layout>
 <#import "register-commons.ftl" as registerCommons>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','user.attributes.gender','user.attributes.birthdate','user.attributes.age_over_18','user.attributes.picture','user.attributes.street','user.attributes.locality','user.attributes.region','user.attributes.postal_code','user.attributes.country','user.attributes.formatted','username','password','password-confirm','termsAccepted'); section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','user.attributes.gender','user.attributes.birthdate','user.attributes.age_over_18','user.attributes.picture','user.attributes.street','user.attributes.locality','user.attributes.region','user.attributes.postal_code','user.attributes.country','user.attributes.formatted','username','email','password','password-confirm','termsAccepted'); section>
     <#if section = "header">
         ${msg("registerTitle")}
     <#elseif section = "form">
@@ -274,6 +274,26 @@
                 </div>
             </#if>
             <!-- /username -->
+
+            <!-- email -->
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="email" class="${properties.kcLabelClass!}">${msg("email")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="email" id="email" class="${properties.kcInputClass!}" name="email"
+                           value="${(register.formData.email!'')}"
+                           aria-invalid="<#if messagesPerField.existsError('email')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('email')>
+                        <span id="input-error-email" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('email'))?no_esc}
+                        </span>
+                    </#if>
+                </div>
+            </div>
+            <!-- /email -->
 
             <!-- password -->
             <#if passwordRequired??>


### PR DESCRIPTION
In newer Keycloak versions it's mandatory.