### PR TITLE
Update waltid mso library to v0.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ didCommon = "1.13.0"
 multiformat = "1.1.0"
 resultMonad = "1.4.0"
 keycloak = "24.0.3"
-waltid = "1.0.2404292350-SNAPSHOT"
+waltid = "0.3.1"
 uri-kmp = "0.0.18"
 
 [libraries]


### PR DESCRIPTION
WaltId has updated their versioning scheme. They no longer provide 'frozen snapshots'. The old version of the mso jvm library is no longer available in their repository and as a result pid-issuer no longer build.

This updates the version of the waltid mso jvm library to the latest available version.

Reference: https://maven.waltid.dev/#/releases/id/walt/waltid-mdoc-credentials-jvm