### PR TITLE
Enable CWT proofs for PID in mso_mdoc

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
@@ -234,7 +234,16 @@ val PidMsoMdocV1: MsoMdocCredentialConfiguration =
         cryptographicBindingMethodsSupported = emptySet(),
         credentialSigningAlgorithmsSupported = emptySet(),
         scope = PidMsoMdocScope,
-        proofTypesSupported = ProofTypesSupported(nonEmptySetOf(ProofType.Jwt(nonEmptySetOf(JWSAlgorithm.ES256)))),
+        proofTypesSupported = ProofTypesSupported(
+            nonEmptySetOf(
+                ProofType.Jwt(nonEmptySetOf(JWSAlgorithm.ES256)),
+                ProofType.Cwt(
+                    algorithms = nonEmptySetOf(CoseAlgorithm.ES256),
+                    curves = nonEmptySetOf(CoseCurve.P_256),
+                ),
+            ),
+        ),
+        policy = MsoMdocPolicy(oneTimeUse = true),
     )
 
 //


### PR DESCRIPTION
Enables proof of type CWT (in addition to JWT) for the PID in `mso_mdoc`

Closes #188 