### PR TITLE
Fix issues with Credential Response Encryption.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
@@ -128,8 +128,7 @@ sealed interface RequestedResponseEncryption {
     ) : RequestedResponseEncryption {
         init {
             require(!encryptionJwk.isPrivate) { "encryptionJwk must not contain a private key" }
-            // When keyUse is null, the JWK can be used for all purposes, including but not limited to ENCRYPTION.
-            require(encryptionJwk.keyUse == null || encryptionJwk.keyUse == KeyUse.ENCRYPTION) {
+            require(encryptionJwk.keyUse == KeyUse.ENCRYPTION) {
                 "encryptionJwk cannot be used for encryption"
             }
             require(encryptionAlgorithm in JWEAlgorithm.Family.ASYMMETRIC) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
@@ -128,7 +128,8 @@ sealed interface RequestedResponseEncryption {
     ) : RequestedResponseEncryption {
         init {
             require(!encryptionJwk.isPrivate) { "encryptionJwk must not contain a private key" }
-            require(KeyUse.ENCRYPTION == encryptionJwk.keyUse) {
+            // When keyUse is null, the JWK can be used for all purposes, including but not limited to ENCRYPTION.
+            require(encryptionJwk.keyUse == null || encryptionJwk.keyUse == KeyUse.ENCRYPTION) {
                 "encryptionJwk cannot be used for encryption"
             }
             require(encryptionAlgorithm in JWEAlgorithm.Family.ASYMMETRIC) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
@@ -257,6 +257,7 @@ class IssueCredential(
                 when (unresolvedRequest) {
                     is UnresolvedCredentialRequest.ByFormat ->
                         unresolvedRequest.credentialRequest to null
+
                     is UnresolvedCredentialRequest.ByCredentialIdentifier ->
                         resolve(unresolvedRequest) to unresolvedRequest.credentialIdentifier
                 }
@@ -370,8 +371,8 @@ private fun CredentialRequestTO.toDomain(
     supported: CredentialResponseEncryption,
 ): UnresolvedCredentialRequest {
     val proof = ensureNotNull(proof) { MissingProof }.toDomain()
-    val credentialResponseEncryption =
-        credentialResponseEncryption?.toDomain(supported) ?: RequestedResponseEncryption.NotRequired
+    val credentialResponseEncryption = credentialResponseEncryption?.toDomain() ?: RequestedResponseEncryption.NotRequired
+    credentialResponseEncryption.ensureIsSupported(supported)
 
     fun credentialRequestByFormat(format: FormatTO): UnresolvedCredentialRequest.ByFormat =
         when (format) {
@@ -459,54 +460,63 @@ private fun ProofTo.toDomain(): UnvalidatedProof = when (type) {
 }
 
 /**
- * Gets the [RequestedResponseEncryption] that corresponds to the provided values.
+ * Verifies this [RequestedResponseEncryption] is supported by the provided [CredentialResponseEncryption], otherwise
+ * raises an [InvalidEncryptionParameters].
  */
 context(Raise<InvalidEncryptionParameters>)
-private fun CredentialResponseEncryptionTO.toDomain(supported: CredentialResponseEncryption): RequestedResponseEncryption.Required =
-    withError({ InvalidEncryptionParameters(it) }) {
-        fun RequestedResponseEncryption.ensureIsSupported() {
-            when (supported) {
-                is CredentialResponseEncryption.NotSupported -> {
-                    if (this is RequestedResponseEncryption.Required) {
-                        // credential response encryption not supported by issuer but required by client
-                        raise(IllegalArgumentException("credential response encryption is not supported"))
-                    }
+private fun RequestedResponseEncryption.ensureIsSupported(supported: CredentialResponseEncryption) {
+    try {
+        when (supported) {
+            is CredentialResponseEncryption.NotSupported -> {
+                if (this is RequestedResponseEncryption.Required) {
+                    // credential response encryption not supported by issuer but required by client
+                    throw IllegalArgumentException("credential response encryption is not supported")
                 }
+            }
 
-                is CredentialResponseEncryption.Optional -> {
-                    if (this is RequestedResponseEncryption.Required) {
-                        // credential response encryption supported by issuer and required by client
-                        // ensure provided parameters are supported
-                        if (encryptionAlgorithm !in supported.parameters.algorithmsSupported) {
-                            raise(IllegalArgumentException("jwe encryption algorithm '${encryptionAlgorithm.name}' is not supported"))
-                        }
-                        if (encryptionMethod !in supported.parameters.methodsSupported) {
-                            raise(IllegalArgumentException("jwe encryption method '${encryptionMethod.name}' is not supported"))
-                        }
-                    }
-                }
-
-                is CredentialResponseEncryption.Required -> {
-                    if (this !is RequestedResponseEncryption.Required) {
-                        // credential response encryption required by issuer but not required by client
-                        raise(IllegalArgumentException("credential response encryption is required"))
-                    }
-
+            is CredentialResponseEncryption.Optional -> {
+                if (this is RequestedResponseEncryption.Required) {
+                    // credential response encryption supported by issuer and required by client
                     // ensure provided parameters are supported
                     if (encryptionAlgorithm !in supported.parameters.algorithmsSupported) {
-                        raise(IllegalArgumentException("jwe encryption algorithm '${encryptionAlgorithm.name}' is not supported"))
+                        throw IllegalArgumentException("jwe encryption algorithm '${encryptionAlgorithm.name}' is not supported")
                     }
                     if (encryptionMethod !in supported.parameters.methodsSupported) {
-                        raise(IllegalArgumentException("jwe encryption method '${encryptionMethod.name}' is not supported"))
+                        throw IllegalArgumentException("jwe encryption method '${encryptionMethod.name}' is not supported")
                     }
                 }
             }
-        }
 
-        RequestedResponseEncryption.Required(Json.encodeToString(key), algorithm, method)
-            .bind()
-            .also { it.ensureIsSupported() }
+            is CredentialResponseEncryption.Required -> {
+                if (this !is RequestedResponseEncryption.Required) {
+                    // credential response encryption required by issuer but not required by client
+                    throw IllegalArgumentException("credential response encryption is required")
+                }
+
+                // ensure provided parameters are supported
+                if (encryptionAlgorithm !in supported.parameters.algorithmsSupported) {
+                    throw IllegalArgumentException("jwe encryption algorithm '${encryptionAlgorithm.name}' is not supported")
+                }
+                if (encryptionMethod !in supported.parameters.methodsSupported) {
+                    throw IllegalArgumentException("jwe encryption method '${encryptionMethod.name}' is not supported")
+                }
+            }
+        }
+    } catch (error: Exception) {
+        raise(InvalidEncryptionParameters(error))
     }
+}
+
+/**
+ * Gets the [RequestedResponseEncryption] that corresponds to the provided values.
+ */
+context(Raise<InvalidEncryptionParameters>)
+private fun CredentialResponseEncryptionTO.toDomain(): RequestedResponseEncryption.Required =
+    RequestedResponseEncryption.Required(
+        Json.encodeToString(key),
+        algorithm,
+        method,
+    ).getOrElse { raise(InvalidEncryptionParameters(it)) }
 
 fun CredentialResponse<JsonElement>.toTO(nonce: CNonce): IssueCredentialResponse.PlainTO =
     when (this) {

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -22,6 +22,7 @@ import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.factories.DefaultJWEDecrypterFactory
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
@@ -457,7 +458,7 @@ internal class WalletApiEncryptionRequiredTest : BaseWalletApiTest() {
         val proof = jwtProof(credentialIssuerMetadata.id, clock, previousCNonce, walletKey) {
             jwk(walletKey.toPublicJWK())
         }
-        val encryptionKey = RSAKeyGenerator(4096).generate()
+        val encryptionKey = RSAKeyGenerator(4096).keyUse(KeyUse.ENCRYPTION).generate()
         val encryptionParameters = encryptionParameters(encryptionKey)
 
         val response = client()
@@ -546,7 +547,7 @@ internal class WalletApiEncryptionRequiredTest : BaseWalletApiTest() {
         val proof = jwtProof(credentialIssuerMetadata.id, clock, previousCNonce, walletKey) {
             jwk(walletKey.toPublicJWK())
         }
-        val encryptionKey = RSAKeyGenerator(4096).generate()
+        val encryptionKey = RSAKeyGenerator(4096).keyUse(KeyUse.ENCRYPTION).generate()
         val encryptionParameters = encryptionParameters(encryptionKey)
 
         val response = client()


### PR DESCRIPTION
1. ~~RequestedResponseEncryption.Required now accepts JWK with keyUse null as well. When keyUse is null, the JWK can be used for all purposes, including encryption.~~
2. Properly verify during issuance that RequestedResponseEncryption is supported by the issuer's configured CredentialResponseEncryption. Previously when CredentialResponseEncryption was set to Required, but the CredentialRequestTO contained no CredentialResponseEncryptionTO, the issuance would continue and an unencrypted credential would be issued, even though the issuer was configured to require encryption.

Closes #204