### PR TITLE
Draft14 - Batch Issuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
 
 ## Overview
 
-An implementation of a credential issuing service, according to OpenId4VCI - draft13
+An implementation of a credential issuing service, according to OpenId4VCI - draft14
 
 The service provides generic support for `mso_mdoc` and `SD-JWT-VC` formats using PID and mDL as an example
 and requires the use of a suitable OAUTH2 server.

--- a/README.md
+++ b/README.md
@@ -28,19 +28,18 @@ and requires the use of a suitable OAUTH2 server.
 
 ### OpenId4VCI coverage
 
-| Feature                                                   | Coverage                                                  |
-|-----------------------------------------------------------|-----------------------------------------------------------|
-| Authorization Code flow                                   | ✅ Using a suitable OAUTH2 server                          |
-| Pre-authorized code flow                                  | ❌                                                         |
-| mso_mdoc format                                           | ✅                                                         |
-| SD-JWT-VC format                                          | ✅ Except revocation list & meta                           |
-| W3C VC DM                                                 | ❌                                                         |
-| Credential Offer                                          | ✅ `authorization_code` , ❌ `pre-authorized_code`          |
-| [Credential Endpoint](#credential-endpoint)               | Yes, including proofs, encryption, repeatable invocations |
-| [Credential Issuer MetaData](#credential-issuer-metadata) | Yes, using `scopes`                                       | 
-| Batch Endpoint                                            | ❌                                                         | 
-| Deferred Endpoint                                         | ✅                                                         |
-| Proof                                                     | ✅ JWT (`jwk`, `x5c`, `did:key`, `did:jwk`)                               |
+| Feature                                                   | Coverage                                                           |
+|-----------------------------------------------------------|--------------------------------------------------------------------|
+| Authorization Code flow                                   | ✅ Using a suitable OAUTH2 server                                   |
+| Pre-authorized code flow                                  | ❌                                                                  |
+| mso_mdoc format                                           | ✅                                                                  |
+| SD-JWT-VC format                                          | ✅ Except revocation list & meta                                    |
+| W3C VC DM                                                 | ❌                                                                  |
+| Credential Offer                                          | ✅ `authorization_code` , ❌ `pre-authorized_code`                   |
+| [Credential Endpoint](#credential-endpoint)               | Yes, including multiple proofs, encryption, repeatable invocations |
+| [Credential Issuer MetaData](#credential-issuer-metadata) | Yes, using `scopes`                                                | 
+| Deferred Endpoint                                         | ✅                                                                  |
+| Proof                                                     | ✅ JWT (`jwk`, `x5c`, `did:key`, `did:jwk`)                         |
 
 ## How to use docker
 
@@ -276,15 +275,17 @@ for signing the issued credentials.
 By default, the server generates a random EC Key alongside a self-signed certificate using the *P-256/secp256r1* 
 curve on startup. If the server is restarted, a new EC Key and self-signed certificate is generated.
 
-In case you opt to use your own EC Key and certificate make sure to use an EC Key that uses one of the following curves:
-* *P-256/secp256r1*
-* *P-384/secp384r1*
-* *P-521/secp521r1*
+> [!TIP]
+> In case you opt to use your own EC Key and certificate, 
+> make sure to use an EC Key that uses one of the following curves:
+> - *P-256/secp256r1*
+> - *P-384/secp384r1*
+> - *P-521/secp521r1*
 
-The signing algorithm is determined by the EC Key used. The server will use one of the following signing algorithms:
-* *ES256*
-* *ES384*
-* *ES512*
+The EC Key used determines the signing algorithm. The server will use one of the following signing algorithms:
+- *ES256*
+- *ES384*
+- *ES512*
 
 To generate an EC Key and self-signed certificate using `keytool` you can use the following command:
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ Variable: `ISSUER_DPOP_REALM`
 Description: Realm to report in the WWW-Authenticate header in case of DPoP authentication/authorization failure         
 Default value: `pid-issuer`
 
+Variable: `ISSUER_CREDENTIALENDPOINT_BATCHISSUANCE_ENABLED`  
+Description: Whether to enable batch issuance support in the credential endpoint         
+Default value: `true`
+
+Variable: `ISSUER_CREDENTIALENDPOINT_BATCHISSUANCE_BATCHSIZE`  
+Description: Maximum length of `proofs` array supported by credential endpoint when batch issuance support is enabled          
+Default value: `10`
+
 ### Signing Key
 
 When either PID issuance in SD-JWT is enabled, or the internal MSO MDoc encoder is used, an EC Key is required 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 coroutines = "1.8.1"
 kotlin = "2.0.0"
 arrow = "1.2.4"
-foojay = "0.8.0"
 springboot = "3.3.1"
 springDependencyManagement = "1.1.5"
 spotless = "6.25.0"
@@ -11,7 +10,7 @@ kotlinxSerialization = "1.7.1"
 ktlint = "0.50.0"
 nimbusJoseJwt = "9.40"
 nimbusOAuth2 = "11.13"
-eudiSdJwt = "0.5.0"
+eudiSdJwt = "0.6.1"
 bouncyCastle = "1.78.1"
 dependencyCheck = "10.0.3"
 sonarqube = "5.0.0.4638"
@@ -25,10 +24,8 @@ uri-kmp = "0.0.18"
 zxing = "3.5.3"
 
 [libraries]
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "kotlinxSerialization" }
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJoseJwt" }
@@ -45,7 +42,6 @@ uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 zxing = { module = "com.google.zxing:javase", version.ref = "zxing" }
 
 [plugins]
-foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -355,8 +355,8 @@ fun beans(clock: Clock) = beans {
     //
     with(InMemoryIssuedCredentialRepository()) {
         bean { GenerateNotificationId.Random }
-        bean { storeIssuedCredential }
-        bean { loadIssuedCredentialByNotificationId }
+        bean { storeIssuedCredentials }
+        bean { loadIssuedCredentialsByNotificationId }
     }
 
     //
@@ -389,7 +389,7 @@ fun beans(clock: Clock) = beans {
                             ?: true,
                         generateNotificationId = ref(),
                         clock = clock,
-                        storeIssuedCredential = ref(),
+                        storeIssuedCredentials = ref(),
                     )
                     add(issueMsoMdocPid)
                 }
@@ -419,7 +419,7 @@ fun beans(clock: Clock) = beans {
                         notificationsEnabled = env.getProperty<Boolean>("issuer.pid.sd_jwt_vc.notifications.enabled")
                             ?: true,
                         generateNotificationId = ref(),
-                        storeIssuedCredential = ref(),
+                        storeIssuedCredentials = ref(),
                     )
 
                     val deferred = env.getProperty<Boolean>("issuer.pid.sd_jwt_vc.deferred") ?: false
@@ -437,7 +437,7 @@ fun beans(clock: Clock) = beans {
                         notificationsEnabled = env.getProperty<Boolean>("issuer.mdl.notifications.enabled") ?: true,
                         generateNotificationId = ref(),
                         clock = clock,
-                        storeIssuedCredential = ref(),
+                        storeIssuedCredentials = ref(),
                     )
                     add(mdlIssuer)
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -530,7 +530,6 @@ fun beans(clock: Clock) = beans {
                 authorize(WalletApi.DEFERRED_ENDPOINT, hasAnyAuthority(*scopes.toTypedArray()))
                 authorize(WalletApi.NOTIFICATION_ENDPOINT, hasAnyAuthority(*scopes.toTypedArray()))
                 authorize(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER, permitAll)
-                authorize(MetaDataApi.WELL_KNOWN_JWKS, permitAll)
                 authorize(MetaDataApi.WELL_KNOWN_JWT_VC_ISSUER, permitAll)
                 authorize(MetaDataApi.PUBLIC_KEYS, permitAll)
                 authorize(IssuerUi.GENERATE_CREDENTIALS_OFFER, permitAll)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -287,9 +287,9 @@ fun beans(clock: Clock) = beans {
         val resolvers = buildMap<CredentialIdentifier, CredentialRequestFactory> {
             if (enableMobileDrivingLicence) {
                 this[CredentialIdentifier(MobileDrivingLicenceV1Scope.value)] =
-                    { unvalidatedProof, requestedResponseEncryption ->
+                    { unvalidatedProofs, requestedResponseEncryption ->
                         MsoMdocCredentialRequest(
-                            unvalidatedProof = unvalidatedProof,
+                            unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
                             docType = MobileDrivingLicenceV1.docType,
                             claims = MobileDrivingLicenceV1.msoClaims.mapValues { entry ->
@@ -301,9 +301,9 @@ fun beans(clock: Clock) = beans {
 
             if (enableMsoMdocPid) {
                 this[CredentialIdentifier(PidMsoMdocScope.value)] =
-                    { unvalidatedProof, requestedResponseEncryption ->
+                    { unvalidatedProofs, requestedResponseEncryption ->
                         MsoMdocCredentialRequest(
-                            unvalidatedProof = unvalidatedProof,
+                            unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
                             docType = PidMsoMdocV1.docType,
                             claims = PidMsoMdocV1.msoClaims.mapValues { entry -> entry.value.map { attribute -> attribute.name } },
@@ -315,9 +315,9 @@ fun beans(clock: Clock) = beans {
                 val signingAlgorithm = ref<IssuerSigningKey>().signingAlgorithm
                 pidSdJwtVcV1(signingAlgorithm).let { sdJwtVcPid ->
                     this[CredentialIdentifier(PidSdJwtVcScope.value)] =
-                        { unvalidatedProof, requestedResponseEncryption ->
+                        { unvalidatedProofs, requestedResponseEncryption ->
                             SdJwtVcCredentialRequest(
-                                unvalidatedProof = unvalidatedProof,
+                                unvalidatedProofs = unvalidatedProofs,
                                 credentialResponseEncryption = requestedResponseEncryption,
                                 type = sdJwtVcPid.type,
                                 claims = sdJwtVcPid.claims.map { it.name }.toSet(),

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -442,6 +442,15 @@ fun beans(clock: Clock) = beans {
                     add(mdlIssuer)
                 }
             },
+            batchCredentialIssuance = run {
+                val enabled = env.getProperty<Boolean>("issuer.credentialEndpoint.batchIssuance.enabled") ?: true
+                if (enabled) {
+                    val batchSize = env.getProperty<Int>("issuer.credentialEndpoint.batchIssuance.batchSize") ?: 10
+                    BatchCredentialIssuance.Supported(batchSize)
+                } else {
+                    BatchCredentialIssuance.NotSupported
+                }
+            },
         )
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -182,6 +182,21 @@ fun beans(clock: Clock) = beans {
     val enableMsoMdocPid = env.getProperty<Boolean>("issuer.pid.mso_mdoc.enabled") ?: true
     val enableSdJwtVcPid = env.getProperty<Boolean>("issuer.pid.sd_jwt_vc.enabled") ?: true
     val credentialsOfferUri = env.getRequiredProperty("issuer.credentialOffer.uri")
+    val batchCredentialIssuance = run {
+        val enabled = env.getProperty<Boolean>("issuer.credentialEndpoint.batchIssuance.enabled") ?: true
+        if (enabled) {
+            val batchSize = env.getProperty<Int>("issuer.credentialEndpoint.batchIssuance.batchSize") ?: 10
+            BatchCredentialIssuance.Supported(batchSize)
+        } else {
+            BatchCredentialIssuance.NotSupported
+        }
+    }
+    val mobileDrivingLicenceV1: MsoMdocCredentialConfiguration by lazy {
+        mobileDrivingLicenceV1(batchCredentialIssuance)
+    }
+    val pidMsoMdocV1: MsoMdocCredentialConfiguration by lazy {
+        pidMsoMdocV1(batchCredentialIssuance)
+    }
 
     //
     // Signing key
@@ -266,7 +281,7 @@ fun beans(clock: Clock) = beans {
         val duration = env.getProperty("issuer.pid.mso_mdoc.encoder.duration")
             ?.let { Duration.parse(it).toKotlinDuration() }
             ?: 30.days
-        DefaultEncodePidInCbor(clock, issuerSigningKey, duration)
+        DefaultEncodePidInCbor(clock, issuerSigningKey, duration, pidMsoMdocV1.docType)
     }
 
     bean {
@@ -278,7 +293,7 @@ fun beans(clock: Clock) = beans {
         val duration = env.getProperty("issuer.mdl.mso_mdoc.encoder.duration")
             ?.let { Duration.parse(it).toKotlinDuration() }
             ?: 5.days
-        DefaultEncodeMobileDrivingLicenceInCbor(clock, issuerSigningKey, duration)
+        DefaultEncodeMobileDrivingLicenceInCbor(clock, issuerSigningKey, duration, mobileDrivingLicenceV1.docType)
     }
 
     bean(::DefaultGenerateQrCode)
@@ -291,8 +306,8 @@ fun beans(clock: Clock) = beans {
                         MsoMdocCredentialRequest(
                             unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
-                            docType = MobileDrivingLicenceV1.docType,
-                            claims = MobileDrivingLicenceV1.msoClaims.mapValues { entry ->
+                            docType = mobileDrivingLicenceV1.docType,
+                            claims = mobileDrivingLicenceV1.msoClaims.mapValues { entry ->
                                 entry.value.map { attribute -> attribute.name }
                             },
                         )
@@ -305,8 +320,8 @@ fun beans(clock: Clock) = beans {
                         MsoMdocCredentialRequest(
                             unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
-                            docType = PidMsoMdocV1.docType,
-                            claims = PidMsoMdocV1.msoClaims.mapValues { entry -> entry.value.map { attribute -> attribute.name } },
+                            docType = pidMsoMdocV1.docType,
+                            claims = pidMsoMdocV1.msoClaims.mapValues { entry -> entry.value.map { attribute -> attribute.name } },
                         )
                     }
             }
@@ -390,6 +405,7 @@ fun beans(clock: Clock) = beans {
                         generateNotificationId = ref(),
                         clock = clock,
                         storeIssuedCredentials = ref(),
+                        supportedCredential = pidMsoMdocV1,
                     )
                     add(issueMsoMdocPid)
                 }
@@ -438,19 +454,12 @@ fun beans(clock: Clock) = beans {
                         generateNotificationId = ref(),
                         clock = clock,
                         storeIssuedCredentials = ref(),
+                        supportedCredential = mobileDrivingLicenceV1,
                     )
                     add(mdlIssuer)
                 }
             },
-            batchCredentialIssuance = run {
-                val enabled = env.getProperty<Boolean>("issuer.credentialEndpoint.batchIssuance.enabled") ?: true
-                if (enabled) {
-                    val batchSize = env.getProperty<Int>("issuer.credentialEndpoint.batchIssuance.batchSize") ?: 10
-                    BatchCredentialIssuance.Supported(batchSize)
-                } else {
-                    BatchCredentialIssuance.NotSupported
-                }
-            },
+            batchCredentialIssuance = batchCredentialIssuance,
         )
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/MetaDataApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/MetaDataApi.kt
@@ -36,9 +36,6 @@ class MetaDataApi(
         GET(WELL_KNOWN_OPENID_CREDENTIAL_ISSUER, accept(MediaType.APPLICATION_JSON)) { _ ->
             handleGetClientIssuerMetaData()
         }
-        GET(WELL_KNOWN_JWKS, accept(MediaType.APPLICATION_JSON)) { _ ->
-            handleGetJwtIssuerJwkSet()
-        }
         GET(WELL_KNOWN_JWT_VC_ISSUER, accept(MediaType.APPLICATION_JSON)) {
             handleGetJwtVcIssuerMetadata()
         }
@@ -49,9 +46,6 @@ class MetaDataApi(
 
     private suspend fun handleGetClientIssuerMetaData(): ServerResponse =
         getCredentialIssuerMetaData().let { metaData -> ServerResponse.ok().json().bodyValueAndAwait(metaData) }
-
-    private suspend fun handleGetJwtIssuerJwkSet(): ServerResponse =
-        TODO()
 
     private suspend fun handleGetJwtVcIssuerMetadata(): ServerResponse =
         ServerResponse.ok()
@@ -70,7 +64,6 @@ class MetaDataApi(
 
     companion object {
         const val WELL_KNOWN_OPENID_CREDENTIAL_ISSUER = "/.well-known/openid-credential-issuer"
-        const val WELL_KNOWN_JWKS = "/.well-known/jwks.json"
         const val WELL_KNOWN_JWT_VC_ISSUER = "/.well-known/jwt-vc-issuer"
         const val PUBLIC_KEYS = "/public_keys.jwks"
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApi.kt
@@ -76,7 +76,7 @@ class WalletApi(
         return when (val response = issueCredential(context, credentialRequest)) {
             is IssueCredentialResponse.PlainTO ->
                 ServerResponse
-                    .status(response.credential?.let { HttpStatus.OK } ?: HttpStatus.ACCEPTED)
+                    .status(response.transactionId?.let { HttpStatus.ACCEPTED } ?: HttpStatus.OK)
                     .json()
                     .bodyValueAndAwait(response)
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DefaultResolveCredentialRequestByCredentialIdentifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DefaultResolveCredentialRequestByCredentialIdentifier.kt
@@ -15,13 +15,14 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.credential
 
+import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIdentifier
 import eu.europa.ec.eudi.pidissuer.domain.CredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
 import eu.europa.ec.eudi.pidissuer.port.out.credential.ResolveCredentialRequestByCredentialIdentifier
 
-typealias CredentialRequestFactory = (UnvalidatedProof, RequestedResponseEncryption) -> CredentialRequest
+typealias CredentialRequestFactory = (NonEmptyList<UnvalidatedProof>, RequestedResponseEncryption) -> CredentialRequest
 
 class DefaultResolveCredentialRequestByCredentialIdentifier(
     private val factories: Map<CredentialIdentifier, CredentialRequestFactory>,
@@ -29,8 +30,8 @@ class DefaultResolveCredentialRequestByCredentialIdentifier(
 
     override suspend fun invoke(
         identifier: CredentialIdentifier,
-        unvalidatedProof: UnvalidatedProof,
+        unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
         credentialResponseEncryption: RequestedResponseEncryption,
     ): CredentialRequest? =
-        factories[identifier]?.let { factory -> factory(unvalidatedProof, credentialResponseEncryption) }
+        factories[identifier]?.let { factory -> factory(unvalidatedProofs, credentialResponseEncryption) }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptResponseWithNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptResponseWithNimbus.kt
@@ -56,10 +56,6 @@ private fun JWTClaimsSet.Builder.credentialOrCredentials(
     credential: JsonElement? = null,
     credentials: JsonArray? = null,
 ) {
-    require((credential != null) xor (credentials != null)) {
-        "exactly one of 'credential' or 'credentials' must be provided"
-    }
-
     credential?.let {
         val value = it.toNimbus()
         claim("credential", value)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
@@ -22,7 +22,6 @@ import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.
 import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.ParameterizedRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.MsoMdocSigner
 import eu.europa.ec.eudi.pidissuer.domain.AttributeDetails
-import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.Unexpected
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
@@ -35,14 +34,13 @@ class DefaultEncodeMobileDrivingLicenceInCbor(
     clock: Clock,
     issuerSigningKey: IssuerSigningKey,
     validityDuration: Duration,
-    docType: MsoDocType,
 ) : EncodeMobileDrivingLicenceInCbor {
 
     private val signer = MsoMdocSigner<MobileDrivingLicence>(
         clock = clock,
         issuerSigningKey = issuerSigningKey,
         validityDuration = validityDuration,
-        docType = docType,
+        docType = MobileDrivingLicenceV1.docType,
     ) { licence ->
         addItemsToSign(licence)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
@@ -22,6 +22,7 @@ import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.
 import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.ParameterizedRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.MsoMdocSigner
 import eu.europa.ec.eudi.pidissuer.domain.AttributeDetails
+import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.Unexpected
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
@@ -34,13 +35,14 @@ class DefaultEncodeMobileDrivingLicenceInCbor(
     clock: Clock,
     issuerSigningKey: IssuerSigningKey,
     validityDuration: Duration,
+    docType: MsoDocType,
 ) : EncodeMobileDrivingLicenceInCbor {
 
     private val signer = MsoMdocSigner<MobileDrivingLicence>(
         clock = clock,
         issuerSigningKey = issuerSigningKey,
         validityDuration = validityDuration,
-        docType = MobileDrivingLicenceV1.docType,
+        docType = docType,
     ) { licence ->
         addItemsToSign(licence)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -272,7 +272,9 @@ val MobileDrivingLicenceDisplay: List<CredentialDisplay> = listOf(
     ),
 )
 
-val MobileDrivingLicenceV1: MsoMdocCredentialConfiguration =
+internal fun mobileDrivingLicenceV1(
+    batchCredentialIssuance: BatchCredentialIssuance,
+): MsoMdocCredentialConfiguration =
     MsoMdocCredentialConfiguration(
         id = CredentialConfigurationId(MobileDrivingLicenceV1Scope.value),
         docType = mdlDocType(1u),
@@ -288,7 +290,10 @@ val MobileDrivingLicenceV1: MsoMdocCredentialConfiguration =
                 ),
             ),
         ),
-        policy = MsoMdocPolicy(oneTimeUse = false, batchSize = 2),
+        policy = when (batchCredentialIssuance) {
+            BatchCredentialIssuance.NotSupported -> MsoMdocPolicy(oneTimeUse = false)
+            is BatchCredentialIssuance.Supported -> MsoMdocPolicy(oneTimeUse = false, batchSize = batchCredentialIssuance.batchSize)
+        },
     )
 
 /**
@@ -302,11 +307,8 @@ class IssueMobileDrivingLicence(
     private val generateNotificationId: GenerateNotificationId,
     private val clock: Clock,
     private val storeIssuedCredentials: StoreIssuedCredentials,
+    override val supportedCredential: MsoMdocCredentialConfiguration,
 ) : IssueSpecificCredential {
-
-    override val supportedCredential: MsoMdocCredentialConfiguration
-        get() = MobileDrivingLicenceV1
-
     override val publicKey: JWK?
         get() = null
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -288,7 +288,7 @@ val MobileDrivingLicenceV1: MsoMdocCredentialConfiguration =
                 ),
             ),
         ),
-        policy = MsoMdocPolicy(oneTimeUse = false, batchSize = 2),
+        policy = MsoMdocPolicy(oneTimeUse = false),
     )
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -272,9 +272,7 @@ val MobileDrivingLicenceDisplay: List<CredentialDisplay> = listOf(
     ),
 )
 
-internal fun mobileDrivingLicenceV1(
-    batchCredentialIssuance: BatchCredentialIssuance,
-): MsoMdocCredentialConfiguration =
+val MobileDrivingLicenceV1: MsoMdocCredentialConfiguration =
     MsoMdocCredentialConfiguration(
         id = CredentialConfigurationId(MobileDrivingLicenceV1Scope.value),
         docType = mdlDocType(1u),
@@ -290,10 +288,7 @@ internal fun mobileDrivingLicenceV1(
                 ),
             ),
         ),
-        policy = when (batchCredentialIssuance) {
-            BatchCredentialIssuance.NotSupported -> MsoMdocPolicy(oneTimeUse = false)
-            is BatchCredentialIssuance.Supported -> MsoMdocPolicy(oneTimeUse = false, batchSize = batchCredentialIssuance.batchSize)
-        },
+        policy = MsoMdocPolicy(oneTimeUse = false, batchSize = 2),
     )
 
 /**
@@ -307,8 +302,11 @@ class IssueMobileDrivingLicence(
     private val generateNotificationId: GenerateNotificationId,
     private val clock: Clock,
     private val storeIssuedCredentials: StoreIssuedCredentials,
-    override val supportedCredential: MsoMdocCredentialConfiguration,
 ) : IssueSpecificCredential {
+
+    override val supportedCredential: MsoMdocCredentialConfiguration
+        get() = MobileDrivingLicenceV1
+
     override val publicKey: JWK?
         get() = null
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -29,7 +29,7 @@ import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.InvalidProof
 import eu.europa.ec.eudi.pidissuer.port.out.IssueSpecificCredential
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
-import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredential
+import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
@@ -301,7 +301,7 @@ class IssueMobileDrivingLicence(
     private val notificationsEnabled: Boolean,
     private val generateNotificationId: GenerateNotificationId,
     private val clock: Clock,
-    private val storeIssuedCredential: StoreIssuedCredential,
+    private val storeIssuedCredentials: StoreIssuedCredentials,
 ) : IssueSpecificCredential {
 
     override val supportedCredential: MsoMdocCredentialConfiguration
@@ -333,27 +333,29 @@ class IssueMobileDrivingLicence(
             if (notificationsEnabled) generateNotificationId()
             else null
 
-        val issuedCredentials = holderKeys.awaitAll().map { holderKey ->
-            val cbor = encodeMobileDrivingLicenceInCbor(licence, holderKey)
-            storeIssuedCredential(
-                IssuedCredential(
-                    format = MSO_MDOC_FORMAT,
-                    type = supportedCredential.docType,
-                    holder = with(licence.driver) {
-                        "${familyName.latin.value} ${givenName.latin.value}"
-                    },
-                    holderPublicKey = holderKey.toPublicJWK(),
-                    issuedAt = clock.instant(),
-                    notificationId = notificationId,
-                ),
-            )
-            cbor
-        }.toNonEmptyListOrNull()
+        val issuedCredentials = holderKeys.awaitAll()
+            .map { holderKey ->
+                val cbor = encodeMobileDrivingLicenceInCbor(licence, holderKey)
+                cbor to holderKey.toPublicJWK()
+            }.toNonEmptyListOrNull()
         ensureNotNull(issuedCredentials) {
             IssueCredentialError.Unexpected("Unable to issue mDL")
         }
 
-        CredentialResponse.Issued(issuedCredentials.map { JsonPrimitive(it) }, notificationId)
+        storeIssuedCredentials(
+            IssuedCredentials(
+                format = MSO_MDOC_FORMAT,
+                type = supportedCredential.docType,
+                holder = with(licence.driver) {
+                    "${familyName.latin.value} ${givenName.latin.value}"
+                },
+                holderPublicKeys = issuedCredentials.map { it.second },
+                issuedAt = clock.instant(),
+                notificationId = notificationId,
+            ),
+        )
+
+        CredentialResponse.Issued(issuedCredentials.map { JsonPrimitive(it.first) }, notificationId)
             .also {
                 log.info("Successfully issued mDL(s)")
                 log.debug("Issued mDL(s) data {}", it)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
@@ -23,7 +23,6 @@ import eu.europa.ec.eudi.pidissuer.port.out.persistence.LoadDeferredCredentialRe
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreDeferredCredential
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.JsonElement
 import org.slf4j.LoggerFactory
 
 /**
@@ -32,7 +31,7 @@ import org.slf4j.LoggerFactory
  */
 data class DeferredState(
     val responseEncryption: RequestedResponseEncryption,
-    val issued: CredentialResponse.Issued<JsonElement>?,
+    val issued: CredentialResponse.Issued?,
 )
 
 private val log = LoggerFactory.getLogger(InMemoryDeferredCredentialRepository::class.java)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryIssuedCredentialRepository.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryIssuedCredentialRepository.kt
@@ -15,9 +15,9 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.persistence
 
-import eu.europa.ec.eudi.pidissuer.domain.IssuedCredential
-import eu.europa.ec.eudi.pidissuer.port.out.persistence.LoadIssuedCredentialByNotificationId
-import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredential
+import eu.europa.ec.eudi.pidissuer.domain.IssuedCredentials
+import eu.europa.ec.eudi.pidissuer.port.out.persistence.LoadIssuedCredentialsByNotificationId
+import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.slf4j.LoggerFactory
@@ -25,12 +25,12 @@ import org.slf4j.LoggerFactory
 private val log = LoggerFactory.getLogger(InMemoryIssuedCredentialRepository::class.java)
 
 class InMemoryIssuedCredentialRepository(
-    private val data: MutableList<IssuedCredential> = mutableListOf(),
+    private val data: MutableList<IssuedCredentials> = mutableListOf(),
 ) {
     private val mutex = Mutex()
 
-    val storeIssuedCredential: StoreIssuedCredential =
-        StoreIssuedCredential { credential ->
+    val storeIssuedCredentials: StoreIssuedCredentials =
+        StoreIssuedCredentials { credential ->
             mutex.withLock(this) {
                 if (credential.notificationId != null) {
                     require(data.find { existing -> existing.notificationId == credential.notificationId } == null) {
@@ -42,8 +42,8 @@ class InMemoryIssuedCredentialRepository(
             }
         }
 
-    val loadIssuedCredentialByNotificationId: LoadIssuedCredentialByNotificationId =
-        LoadIssuedCredentialByNotificationId { notificationId ->
+    val loadIssuedCredentialsByNotificationId: LoadIssuedCredentialsByNotificationId =
+        LoadIssuedCredentialsByNotificationId { notificationId ->
             mutex.withLock(this) {
                 data.find { credential -> credential.notificationId == notificationId }
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
@@ -19,6 +19,7 @@ import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.MsoMdocSigner
 import eu.europa.ec.eudi.pidissuer.domain.AttributeDetails
+import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
@@ -28,16 +29,16 @@ import kotlin.time.Duration
 
 internal class DefaultEncodePidInCbor(
     clock: Clock,
-    issuerSigningKey:
-        IssuerSigningKey,
+    issuerSigningKey: IssuerSigningKey,
     validityDuration: Duration,
+    docType: MsoDocType,
 ) : EncodePidInCbor {
 
     private val signer = MsoMdocSigner<Pair<Pid, PidMetaData>>(
         clock = clock,
         issuerSigningKey = issuerSigningKey,
         validityDuration = validityDuration,
-        docType = PidMsoMdocV1.docType,
+        docType = docType,
     ) { (pid, pidMetaData) ->
         addItemsToSign(pid)
         addItemsToSign(pidMetaData)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
@@ -19,7 +19,6 @@ import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.MsoMdocSigner
 import eu.europa.ec.eudi.pidissuer.domain.AttributeDetails
-import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
@@ -29,16 +28,16 @@ import kotlin.time.Duration
 
 internal class DefaultEncodePidInCbor(
     clock: Clock,
-    issuerSigningKey: IssuerSigningKey,
+    issuerSigningKey:
+        IssuerSigningKey,
     validityDuration: Duration,
-    docType: MsoDocType,
 ) : EncodePidInCbor {
 
     private val signer = MsoMdocSigner<Pair<Pid, PidMetaData>>(
         clock = clock,
         issuerSigningKey = issuerSigningKey,
         validityDuration = validityDuration,
-        docType = docType,
+        docType = PidMsoMdocV1.docType,
     ) { (pid, pidMetaData) ->
         addItemsToSign(pid)
         addItemsToSign(pidMetaData)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
@@ -227,9 +227,7 @@ private val pidAttributes = PidMsoMdocNamespace to listOf(
     IssuingJurisdictionAttribute,
 )
 
-internal fun pidMsoMdocV1(
-    batchCredentialIssuance: BatchCredentialIssuance,
-): MsoMdocCredentialConfiguration =
+val PidMsoMdocV1: MsoMdocCredentialConfiguration =
     MsoMdocCredentialConfiguration(
         id = CredentialConfigurationId(PidMsoMdocScope.value),
         docType = pidDocType(1),
@@ -243,10 +241,7 @@ internal fun pidMsoMdocV1(
                 ProofType.Jwt(nonEmptySetOf(JWSAlgorithm.ES256)),
             ),
         ),
-        policy = when (batchCredentialIssuance) {
-            BatchCredentialIssuance.NotSupported -> MsoMdocPolicy(oneTimeUse = true)
-            is BatchCredentialIssuance.Supported -> MsoMdocPolicy(oneTimeUse = true, batchSize = batchCredentialIssuance.batchSize)
-        },
+        policy = MsoMdocPolicy(oneTimeUse = true),
     )
 
 //
@@ -270,12 +265,13 @@ class IssueMsoMdocPid(
     private val generateNotificationId: GenerateNotificationId,
     private val clock: Clock,
     private val storeIssuedCredentials: StoreIssuedCredentials,
-    override val supportedCredential: MsoMdocCredentialConfiguration,
 ) : IssueSpecificCredential {
 
     private val log = LoggerFactory.getLogger(IssueMsoMdocPid::class.java)
 
     private val validateProof = ValidateProof(credentialIssuerId)
+    override val supportedCredential: MsoMdocCredentialConfiguration
+        get() = PidMsoMdocV1
     override val publicKey: JWK? = null
 
     context(Raise<IssueCredentialError>)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -90,9 +90,7 @@ data class CredentialIssuerDisplay(
  * @param credentialEndPoint URL of the Credential Issuer's Credential Endpoint.
  * This URL MUST use the https scheme and MAY contain port, path,
  * and query parameter components
- * @param batchCredentialEndpoint URL of the Credential Issuer's Batch Credential Endpoint.
- * This URL MUST use the https scheme and MAY contain port, path, and query parameter components.
- * If omitted, the Credential Issuer does not support the Batch Credential Endpoint
+ * @param batchCredentialIssuance whether the credential endpoint supports batch issuance or not
  * @param deferredCredentialEndpoint  URL of the Credential Issuer's
  * Deferred Credential Endpoint. This URL MUST use the https scheme and MAY contain port, path,
  * and query parameter components.
@@ -109,7 +107,7 @@ data class CredentialIssuerMetaData(
     val id: CredentialIssuerId,
     val authorizationServers: List<HttpsUrl>,
     val credentialEndPoint: HttpsUrl,
-    val batchCredentialEndpoint: HttpsUrl? = null,
+    val batchCredentialIssuance: BatchCredentialIssuance,
     val deferredCredentialEndpoint: HttpsUrl? = null,
     val notificationEndpoint: HttpsUrl? = null,
     val credentialResponseEncryption: CredentialResponseEncryption,
@@ -118,4 +116,24 @@ data class CredentialIssuerMetaData(
 ) {
     val credentialConfigurationsSupported: List<CredentialConfiguration>
         get() = specificCredentialIssuers.map { it.supportedCredential }
+}
+
+/**
+ * Indicates whether the Credential Endpoint can support batch issuance or not.
+ */
+sealed interface BatchCredentialIssuance {
+
+    /**
+     * Batch credential issuance is not supported.
+     */
+    data object NotSupported : BatchCredentialIssuance
+
+    /**
+     * Batch credential issuance is supported.
+     */
+    data class Supported(val batchSize: Int) : BatchCredentialIssuance {
+        init {
+            require(batchSize > 0) { "Batch size must be greater than 0" }
+        }
+    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -19,7 +19,6 @@ import arrow.core.NonEmptySet
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import eu.europa.ec.eudi.pidissuer.port.out.IssueSpecificCredential
-import kotlinx.serialization.json.JsonElement
 
 /**
  * Encryption algorithms and methods supported for encrypting Credential Responses.
@@ -115,7 +114,7 @@ data class CredentialIssuerMetaData(
     val notificationEndpoint: HttpsUrl? = null,
     val credentialResponseEncryption: CredentialResponseEncryption,
     val display: List<CredentialIssuerDisplay> = emptyList(),
-    val specificCredentialIssuers: List<IssueSpecificCredential<JsonElement>>,
+    val specificCredentialIssuers: List<IssueSpecificCredential>,
 ) {
     val credentialConfigurationsSupported: List<CredentialConfiguration>
         get() = specificCredentialIssuers.map { it.supportedCredential }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
@@ -149,7 +149,7 @@ sealed interface RequestedResponseEncryption {
  */
 sealed interface CredentialRequest {
     val format: Format
-    val unvalidatedProof: UnvalidatedProof
+    val unvalidatedProofs: NonEmptyList<UnvalidatedProof>
     val credentialResponseEncryption: RequestedResponseEncryption
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialResponse.kt
@@ -15,6 +15,9 @@
  */
 package eu.europa.ec.eudi.pidissuer.domain
 
+import arrow.core.NonEmptyList
+import kotlinx.serialization.json.JsonElement
+
 /**
  * String identifying an issued Credential that the Wallet includes in the Notification Request.
  */
@@ -30,16 +33,16 @@ value class TransactionId(val value: String)
 /**
  * The response to a Credential Request.
  */
-sealed interface CredentialResponse<out T> {
+sealed interface CredentialResponse {
 
     /**
      * An unencrypted Credential has been issued.
      */
-    data class Issued<T>(val credential: T, val notificationId: NotificationId? = null) : CredentialResponse<T>
+    data class Issued(val credentials: NonEmptyList<JsonElement>, val notificationId: NotificationId? = null) : CredentialResponse
 
     /**
      * The issuance of the requested Credential has been deferred.
      * The deferred transaction can be identified by [transactionId].
      */
-    data class Deferred(val transactionId: TransactionId) : CredentialResponse<Nothing>
+    data class Deferred(val transactionId: TransactionId) : CredentialResponse
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
@@ -20,7 +20,6 @@ import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import com.nimbusds.jose.JWSAlgorithm
-import kotlinx.serialization.SerialName
 
 //
 // Credential MetaData
@@ -33,10 +32,7 @@ const val MSO_MDOC_FORMAT_VALUE = "mso_mdoc"
 val MSO_MDOC_FORMAT = Format(MSO_MDOC_FORMAT_VALUE)
 typealias MsoClaims = Map<MsoNameSpace, List<AttributeDetails>>
 
-data class MsoMdocPolicy(
-    @SerialName("one_time_use") val oneTimeUse: Boolean,
-    @SerialName("batch_size") val batchSize: Int? = null,
-)
+data class MsoMdocPolicy(val oneTimeUse: Boolean)
 
 /**
  * @param docType string identifying the credential type as defined in ISO.18013-5.

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.domain
 
+import arrow.core.NonEmptyList
 import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
@@ -56,7 +57,7 @@ data class MsoMdocCredentialConfiguration(
 // Credential Request
 //
 data class MsoMdocCredentialRequest(
-    override val unvalidatedProof: UnvalidatedProof,
+    override val unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
     override val credentialResponseEncryption: RequestedResponseEncryption = RequestedResponseEncryption.NotRequired,
     val docType: MsoDocType,
     val claims: Map<MsoNameSpace, List<MsoMdocAttributeName>> = emptyMap(),

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.domain
 
+import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
 import arrow.core.raise.Raise
 import arrow.core.raise.ensure
@@ -44,7 +45,7 @@ data class SdJwtVcCredentialConfiguration(
 // Credential Offer
 //
 data class SdJwtVcCredentialRequest(
-    override val unvalidatedProof: UnvalidatedProof,
+    override val unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
     override val credentialResponseEncryption: RequestedResponseEncryption = RequestedResponseEncryption.NotRequired,
     val type: SdJwtVcType,
     val claims: Set<String> = emptySet(),

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.domain
 
+import arrow.core.NonEmptyList
 import com.nimbusds.jose.jwk.JWK
 import org.slf4j.LoggerFactory
 import java.net.MalformedURLException
@@ -105,13 +106,13 @@ sealed interface CryptographicBindingMethod {
 }
 
 /**
- * A credential that was issued by a specific issuing service.
+ * Credential that have issued by a specific issuing service.
  */
-data class IssuedCredential(
+data class IssuedCredentials(
     val format: Format,
     val type: String,
     val holder: String,
-    val holderPublicKey: JWK,
+    val holderPublicKeys: NonEmptyList<JWK>,
     val issuedAt: Instant,
     val notificationId: NotificationId? = null,
 )

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
@@ -37,14 +37,14 @@ data class CredentialIssuerMetaDataTO(
     val authorizationServers: List<String>? = null,
     @Required @SerialName("credential_endpoint")
     val credentialEndpoint: String,
-    @SerialName("batch_credential_endpoint")
-    val batchCredentialEndpoint: String? = null,
     @SerialName("deferred_credential_endpoint")
     val deferredCredentialEndpoint: String? = null,
     @SerialName("notification_endpoint")
     val notificationEndpoint: String? = null,
     @SerialName("credential_response_encryption")
     val credentialResponseEncryption: CredentialResponseEncryptionTO? = null,
+    @SerialName("batch_credential_issuance")
+    val batchCredentialIssuance: BatchCredentialIssuanceTO? = null,
     @SerialName("credential_identifiers_supported")
     val credentialIdentifiersSupported: Boolean? = null,
     @SerialName("signed_metadata")
@@ -63,6 +63,11 @@ data class CredentialIssuerMetaDataTO(
         val encryptionMethods: List<String>,
         @Required @SerialName("encryption_required")
         val required: Boolean,
+    )
+
+    @Serializable
+    data class BatchCredentialIssuanceTO(
+        @Required @SerialName("batch_size") val batchSize: Int,
     )
 }
 
@@ -88,10 +93,13 @@ private fun CredentialIssuerMetaData.toTransferObject(): CredentialIssuerMetaDat
     credentialIssuer = id.externalForm,
     authorizationServers = authorizationServers.map { it.externalForm },
     credentialEndpoint = credentialEndPoint.externalForm,
-    batchCredentialEndpoint = batchCredentialEndpoint?.externalForm,
     deferredCredentialEndpoint = deferredCredentialEndpoint?.externalForm,
     notificationEndpoint = notificationEndpoint?.externalForm,
     credentialResponseEncryption = credentialResponseEncryption.toTransferObject().getOrNull(),
+    batchCredentialIssuance = when (batchCredentialIssuance) {
+        BatchCredentialIssuance.NotSupported -> null
+        is BatchCredentialIssuance.Supported -> CredentialIssuerMetaDataTO.BatchCredentialIssuanceTO(batchCredentialIssuance.batchSize)
+    },
     credentialIdentifiersSupported = true,
     signedMetadata = null,
     display = display.map { it.toTransferObject() }.takeIf { it.isNotEmpty() },

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/HandleNotificationRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/HandleNotificationRequest.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.pidissuer.port.input
 
 import arrow.core.Either
 import eu.europa.ec.eudi.pidissuer.domain.NotificationId
-import eu.europa.ec.eudi.pidissuer.port.out.persistence.LoadIssuedCredentialByNotificationId
+import eu.europa.ec.eudi.pidissuer.port.out.persistence.LoadIssuedCredentialsByNotificationId
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -93,7 +93,7 @@ private val log = LoggerFactory.getLogger(HandleNotificationRequest::class.java)
  * Handles an incoming Notification Request.
  */
 class HandleNotificationRequest(
-    private val loadIssuedCredentialByNotificationId: LoadIssuedCredentialByNotificationId,
+    private val loadIssuedCredentialsByNotificationId: LoadIssuedCredentialsByNotificationId,
 ) {
     suspend operator fun invoke(requestBody: JsonElement): NotificationResponse =
         Either.catch { Json.decodeFromJsonElement<NotificationRequestTO>(requestBody) }
@@ -101,10 +101,10 @@ class HandleNotificationRequest(
                 ifLeft = { NotificationResponse.NotificationErrorResponseTO(ErrorTypeTO.InvalidNotificationRequest) },
                 ifRight = { notificationRequest ->
                     val notificationId = NotificationId(notificationRequest.notificationId)
-                    val credential = loadIssuedCredentialByNotificationId(notificationId)
+                    val credentials = loadIssuedCredentialsByNotificationId(notificationId)
 
-                    credential?.let {
-                        log.info("Received Notification Request '$notificationRequest' for Credential '$it'")
+                    credentials?.let {
+                        log.info("Received Notification Request '$notificationRequest' for Credentials '$it'")
                         NotificationResponse.Success
                     } ?: NotificationResponse.NotificationErrorResponseTO(ErrorTypeTO.InvalidNotificationId)
                 },

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/ResolveCredentialRequestByCredentialIdentifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/ResolveCredentialRequestByCredentialIdentifier.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.port.out.credential
 
+import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIdentifier
 import eu.europa.ec.eudi.pidissuer.domain.CredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
@@ -28,7 +29,7 @@ fun interface ResolveCredentialRequestByCredentialIdentifier {
 
     suspend operator fun invoke(
         identifier: CredentialIdentifier,
-        unvalidatedProof: UnvalidatedProof,
+        unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
         credentialResponseEncryption: RequestedResponseEncryption,
     ): CredentialRequest?
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/LoadDeferredCredentialByTransactionId.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/LoadDeferredCredentialByTransactionId.kt
@@ -18,11 +18,10 @@ package eu.europa.ec.eudi.pidissuer.port.out.persistence
 import eu.europa.ec.eudi.pidissuer.domain.CredentialResponse
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
 import eu.europa.ec.eudi.pidissuer.domain.TransactionId
-import kotlinx.serialization.json.JsonElement
 
 sealed interface LoadDeferredCredentialResult {
     data class Found(
-        val credential: CredentialResponse.Issued<JsonElement>,
+        val credential: CredentialResponse.Issued,
         val responseEncryption: RequestedResponseEncryption,
     ) : LoadDeferredCredentialResult
     data object InvalidTransactionId : LoadDeferredCredentialResult

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/LoadIssuedCredentialsByNotificationId.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/LoadIssuedCredentialsByNotificationId.kt
@@ -15,13 +15,13 @@
  */
 package eu.europa.ec.eudi.pidissuer.port.out.persistence
 
-import eu.europa.ec.eudi.pidissuer.domain.IssuedCredential
+import eu.europa.ec.eudi.pidissuer.domain.IssuedCredentials
 import eu.europa.ec.eudi.pidissuer.domain.NotificationId
 
-fun interface LoadIssuedCredentialByNotificationId {
+fun interface LoadIssuedCredentialsByNotificationId {
 
     /**
      * Loads an issued credential by its notification id.
      */
-    suspend operator fun invoke(notificationId: NotificationId): IssuedCredential?
+    suspend operator fun invoke(notificationId: NotificationId): IssuedCredentials?
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/StoreDeferredCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/StoreDeferredCredential.kt
@@ -18,12 +18,11 @@ package eu.europa.ec.eudi.pidissuer.port.out.persistence
 import eu.europa.ec.eudi.pidissuer.domain.CredentialResponse
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
 import eu.europa.ec.eudi.pidissuer.domain.TransactionId
-import kotlinx.serialization.json.JsonElement
 
 fun interface StoreDeferredCredential {
     suspend operator fun invoke(
         transactionId: TransactionId,
-        credential: CredentialResponse.Issued<JsonElement>?,
+        credential: CredentialResponse.Issued?,
         credentialResponseEncryption: RequestedResponseEncryption,
     )
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/StoreIssuedCredentials.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/persistence/StoreIssuedCredentials.kt
@@ -15,12 +15,12 @@
  */
 package eu.europa.ec.eudi.pidissuer.port.out.persistence
 
-import eu.europa.ec.eudi.pidissuer.domain.IssuedCredential
+import eu.europa.ec.eudi.pidissuer.domain.IssuedCredentials
 
-fun interface StoreIssuedCredential {
+fun interface StoreIssuedCredentials {
 
     /**
      * Stores an issued credential
      */
-    suspend operator fun invoke(credential: IssuedCredential)
+    suspend operator fun invoke(credentials: IssuedCredentials)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,8 @@ issuer.signing-key=GenerateRandom
 issuer.dpop.proof-max-age=PT1M
 issuer.dpop.cache-purge-interval=PT10M
 issuer.dpop.realm=pid-issuer
+issuer.credentialEndpoint.batchIssuance.enabled=true
+issuer.credentialEndpoint.batchIssuance.batchSize=10
 
 #
 # Resource Server configuration

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptCredentialResponseWithNimbusTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptCredentialResponseWithNimbusTest.kt
@@ -32,7 +32,6 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialResponse
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -40,12 +39,11 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import java.time.Clock
 import java.time.Duration
-import java.util.UUID
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class EncryptCredentialResponseWithNimbusTest {
 
     private val issuer = CredentialIssuerId.unsafe("https://eudi.ec.europa.eu/issuer")
@@ -61,9 +59,10 @@ internal class EncryptCredentialResponseWithNimbusTest {
         val jwk = key.toPublicJWK()
         val parameters = RequestedResponseEncryption.Required(jwk, JWEAlgorithm.RSA_OAEP_512)
         val unencrypted = IssueCredentialResponse.PlainTO(
-            JsonPrimitive("credential"),
-            null,
-            "nonce",
+            credential = JsonPrimitive("credential"),
+            credentials = null,
+            transactionId = null,
+            nonce = "nonce",
             Duration.ofMinutes(5L).seconds,
             UUID.randomUUID().toString(),
         )
@@ -80,9 +79,10 @@ internal class EncryptCredentialResponseWithNimbusTest {
         val jwk = key.toPublicJWK()
         val parameters = RequestedResponseEncryption.Required(jwk, JWEAlgorithm.ECDH_ES_A256KW)
         val unencrypted = IssueCredentialResponse.PlainTO(
-            JsonPrimitive("credential"),
-            null,
-            "nonce",
+            credential = JsonPrimitive("credential"),
+            credentials = null,
+            transactionId = null,
+            nonce = "nonce",
             Duration.ofMinutes(5L).seconds,
             UUID.randomUUID().toString(),
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
@@ -16,12 +16,12 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.jose
 
 import arrow.core.raise.either
-import eu.europa.ec.eudi.pidissuer.adapter.out.pid.pidMsoMdocV1
-import eu.europa.ec.eudi.pidissuer.domain.BatchCredentialIssuance
+import eu.europa.ec.eudi.pidissuer.adapter.out.pid.PidMsoMdocV1
 import eu.europa.ec.eudi.pidissuer.domain.CNonce
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import java.time.Clock
 import kotlin.test.Test
@@ -29,18 +29,18 @@ import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateProofTest {
 
     private val issuer = CredentialIssuerId.unsafe("https://eudi.ec.europa.eu/issuer")
     private val validateProof = ValidateProof(issuer)
     private val clock = Clock.systemDefaultZone()
-    private val pidMsoMdocV1 = pidMsoMdocV1(BatchCredentialIssuance.NotSupported)
 
     @Test
     internal fun `fails with unsupported proof type`() = runTest {
         val nonce = CNonce("token", "nonce", clock.instant(), 5.minutes.toJavaDuration())
         val proof = UnvalidatedProof.LdpVp("foo")
-        val result = either { validateProof(proof, nonce, pidMsoMdocV1) }
+        val result = either { validateProof(proof, nonce, PidMsoMdocV1) }
         assert(result.isLeft())
         assertIs<IssueCredentialError.InvalidProof>(result.leftOrNull())
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
@@ -16,12 +16,12 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.jose
 
 import arrow.core.raise.either
-import eu.europa.ec.eudi.pidissuer.adapter.out.pid.PidMsoMdocV1
+import eu.europa.ec.eudi.pidissuer.adapter.out.pid.pidMsoMdocV1
+import eu.europa.ec.eudi.pidissuer.domain.BatchCredentialIssuance
 import eu.europa.ec.eudi.pidissuer.domain.CNonce
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import java.time.Clock
 import kotlin.test.Test
@@ -29,18 +29,18 @@ import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateProofTest {
 
     private val issuer = CredentialIssuerId.unsafe("https://eudi.ec.europa.eu/issuer")
     private val validateProof = ValidateProof(issuer)
     private val clock = Clock.systemDefaultZone()
+    private val pidMsoMdocV1 = pidMsoMdocV1(BatchCredentialIssuance.NotSupported)
 
     @Test
     internal fun `fails with unsupported proof type`() = runTest {
         val nonce = CNonce("token", "nonce", clock.instant(), 5.minutes.toJavaDuration())
         val proof = UnvalidatedProof.LdpVp("foo")
-        val result = either { validateProof(proof, nonce, PidMsoMdocV1) }
+        val result = either { validateProof(proof, nonce, pidMsoMdocV1) }
         assert(result.isLeft())
         assertIs<IssueCredentialError.InvalidProof>(result.leftOrNull())
     }


### PR DESCRIPTION
Closes #207 
Closes #206

To do:
- [x]  Test it with vci lib draft 13
- [x] Test it with vci lib draft 14 (https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-openid4vci-kt/pull/312)
- [x] Consider including to the PR #206. If a limit is set for the number of the proofs this should be validated, while processing the issuance request 

The new version of the PID Issuer should be compatible with d13 wallets, except the batch endpoint.
Wallets supporting d14, should be able to use the new feature of request batch issuance via the usual credential endpoint.


> [!NOTE]
> In Draft 14, `notification_id` & the response of deferred endpoint were not properly adjusted against the `credentials` array. 
> This PR adapts the changes that will be introduced in draft 15, for the deferred response. 
