### PR TITLE
Properly apply and fix incorrect assertion.

### DIFF
--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -201,8 +201,8 @@ internal class WalletApiEncryptionOptionalTest : BaseWalletApiTest() {
                 {
                     it.expectBody()
                         .jsonPath("$.trace")
-                        .value<String> { value ->
-                            value.contains("Polymorphic serializer was not found for class discriminator")
+                        .value<String> {
+                            assertTrue { "FormatTO does not contain element with name 'pid'" in it }
                         }
                 },
             )


### PR DESCRIPTION
An assertion in a test case in `WalletApiTest` was:
1. Incorrect
2. Not properly applied

This PR fixes the above issues.