### PR TITLE
Make credential issuer display metadata configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,27 @@ Variable: `ISSUER_CREDENTIALENDPOINT_BATCHISSUANCE_BATCHSIZE`
 Description: Maximum length of `proofs` array supported by credential endpoint when batch issuance support is enabled          
 Default value: `10`
 
+### Metadata configuration
+
+You can configure the display objects of the Credential Issuer Metadata of PID Issuer, using the following 
+environment variables. 
+For each display object you must configure as a bare minimum either the name or the logo uri.
+Only one display object can be configured per locale.
+
+Replace `XX` with the index of the display object you want to configure.
+
+Variable: `ISSUER_METADATA_DISPLAY_XX_NAME` (e.g. `ISSUER_METADATA_DISPLAY_0_NAME`)    
+Description: Display name for the Credential Issuer  
+
+Variable: `ISSUER_METADATA_DISPLAY_XX_LOCALE` (e.g. `ISSUER_METADATA_DISPLAY_0_LOCALE`)    
+Description: Language tag of this display object  
+
+Variable: `ISSUER_METADATA_DISPLAY_XX_LOGO_URI` (e.g. `ISSUER_METADATA_DISPLAY_0_LOGO_URI`)  
+Description: URI where the Wallet can obtain the logo of the Credential Issuer  
+
+Variable: `ISSUER_METADATA_DISPLAY_XX_LOGO_ALTERNATIVETEXT` (e.g. `ISSUER_METADATA_DISPLAY_0_LOGO_ALTERNATIVETEXT`)  
+Description: Alternative text for the logo image  
+
 ### Signing Key
 
 When either PID issuance in SD-JWT is enabled, or the internal MSO MDoc encoder is used, an EC Key is required 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -19,6 +19,7 @@ import arrow.core.NonEmptySet
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import eu.europa.ec.eudi.pidissuer.port.out.IssueSpecificCredential
+import java.util.Locale
 
 /**
  * Encryption algorithms and methods supported for encrypting Credential Responses.
@@ -79,9 +80,16 @@ fun <T> CredentialResponseEncryption.fold(
 }
 
 data class CredentialIssuerDisplay(
-    val name: DisplayName? = null,
+    val name: String? = null,
+    val locale: Locale? = null,
     val logo: ImageUri? = null,
-)
+) {
+    init {
+        require(name != null || logo != null) {
+            "provide at least one of 'name' or 'logo'"
+        }
+    }
+}
 
 /**
  * @param id The Credential Issuer's identifier
@@ -114,6 +122,13 @@ data class CredentialIssuerMetaData(
     val display: List<CredentialIssuerDisplay> = emptyList(),
     val specificCredentialIssuers: List<IssueSpecificCredential>,
 ) {
+    init {
+        val displayLocales = display.map { it.locale }
+        require(displayLocales.size == displayLocales.distinct().size) {
+            "only one display object can be configured per locale"
+        }
+    }
+
     val credentialConfigurationsSupported: List<CredentialConfiguration>
         get() = specificCredentialIssuers.map { it.supportedCredential }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
@@ -129,8 +129,8 @@ private fun CredentialResponseEncryption.toTransferObject(): Option<CredentialIs
 
 private fun CredentialIssuerDisplay.toTransferObject(): DisplayTO =
     DisplayTO(
-        name = name?.name,
-        locale = name?.locale?.toString(),
+        name = name,
+        locale = locale?.toString(),
         logo = logo?.toTransferObject(),
     )
 


### PR DESCRIPTION
This PR adds new configuration properties for the Display objects of the Credential Issuer Metadata.


The following configuration properties:
```properties
issuer.metadata.display[0].name=Digital Credentials Issuer
issuer.metadata.display[0].locale=en
issuer.metadata.display[0].logo.uri=https://eudiw.dev/ic-logo.svg
issuer.metadata.display[0].logo.alternative-text=EU Digital Identity Wallet Logo
issuer.metadata.display[1].name=\u0395\u03ba\u03b4\u03cc\u03c4\u03b7\u03c2 \u03a8\u03b7\u03c6\u03b9\u03b1\u03ba\u03ce\u03bd \u0394\u03b9\u03b1\u03c0\u03b9\u03c3\u03c4\u03b5\u03c5\u03c4\u03b7\u03c1\u03af\u03c9\u03bd
issuer.metadata.display[1].locale=el
issuer.metadata.display[1].logo.uri=https://eudiw.dev/ic-logo.svg
issuer.metadata.display[1].logo.alternative-text=\u039b\u03bf\u03b3\u03cc\u03c4\u03c5\u03c0\u03bf \u0395\u03c5\u03c1\u03c9\u03c0\u03b1\u03ca\u03ba\u03bf\u03cd \u03a8\u03b7\u03c6\u03b9\u03b1\u03ba\u03bf\u03cd \u03a0\u03bf\u03c1\u03c4\u03bf\u03c6\u03bf\u03bb\u03b9\u03bf\u03cd
```

The following YAML:
```yaml
issuer:
  metadata:
    display:
      - name: Digital Credentials Issuer
        locale: en
        logo:
          uri: https://eudiw.dev/ic-logo.svg
          alternative-text: EU Digital Identity Wallet Logo
      - name: Εκδότης Ψηφιακών Διαπιστευτηρίων
        locale: el
        logo:
          uri: https://eudiw.dev/ic-logo.svg
          alternative-text: Λογότυπο Ευρωπαϊκού Ψηφιακού Πορτοφολιού
```

The following environment variables:
```
ISSUER_METADATA_DISPLAY_0_LOCALE=en
ISSUER_METADATA_DISPLAY_0_LOGO_ALTERNATIVETEXT=EU Digital Identity Wallet Logo
ISSUER_METADATA_DISPLAY_0_LOGO_URI=https://eudiw.dev/ic-logo.svg
ISSUER_METADATA_DISPLAY_0_NAME=Digital Credentials Issuer
ISSUER_METADATA_DISPLAY_1_LOCALE=gr
ISSUER_METADATA_DISPLAY_1_LOGO_ALTERNATIVETEXT=Λογότυπο Ευρωπαϊκού Ψηφιακού Πορτοφολιού
ISSUER_METADATA_DISPLAY_1_LOGO_URI=https://eudiw.dev/ic-logo.svg
ISSUER_METADATA_DISPLAY_1_NAME=Εκδότης Ψηφιακών Διαπιστευτηρίων
```

All result in the following display array being added to the metadata of the credential issuer:
```json
{
  "display": [
    {
      "name": "Digital Credentials Issuer",
      "locale": "en",
      "logo": {
        "uri": "https://eudiw.dev/ic-logo.svg",
        "alt_text": "EU Digital Identity Wallet Logo"
      }
    },
    {
      "name": "Εκδότης Ψηφιακών Διαπιστευτηρίων",
      "locale": "el",
      "logo": {
        "uri": "https://eudiw.dev/ic-logo.svg",
        "alt_text": "Λογότυπο Ευρωπαϊκού Ψηφιακού Πορτοφολιού"
      }
    }
  ]
}
```

:exclamation: When using property files any UTF-8 literals have to encoded using [native2ascii](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/native2ascii.html).

Closes #259