### PR TITLE
Remove `claims` from SD-JWT VC and MSO MDoc Credential Requests.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -313,9 +313,6 @@ fun beans(clock: Clock) = beans {
                             unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
                             docType = MobileDrivingLicenceV1.docType,
-                            claims = MobileDrivingLicenceV1.msoClaims.mapValues { entry ->
-                                entry.value.map { attribute -> attribute.name }
-                            },
                         )
                     }
             }
@@ -327,7 +324,6 @@ fun beans(clock: Clock) = beans {
                             unvalidatedProofs = unvalidatedProofs,
                             credentialResponseEncryption = requestedResponseEncryption,
                             docType = PidMsoMdocV1.docType,
-                            claims = PidMsoMdocV1.msoClaims.mapValues { entry -> entry.value.map { attribute -> attribute.name } },
                         )
                     }
             }
@@ -341,7 +337,6 @@ fun beans(clock: Clock) = beans {
                                 unvalidatedProofs = unvalidatedProofs,
                                 credentialResponseEncryption = requestedResponseEncryption,
                                 type = sdJwtVcPid.type,
-                                claims = sdJwtVcPid.claims.map { it.name }.toSet(),
                             )
                         }
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
@@ -49,7 +49,6 @@ internal fun SdJwtVcCredentialConfiguration.credentialRequest(
     unvalidatedProofs = unvalidatedProofs,
     credentialResponseEncryption = credentialResponseEncryption,
     type = type,
-    claims = claims.map { it.name }.toSet(),
 )
 
 //
@@ -59,19 +58,12 @@ data class SdJwtVcCredentialRequest(
     override val unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
     override val credentialResponseEncryption: RequestedResponseEncryption = RequestedResponseEncryption.NotRequired,
     val type: SdJwtVcType,
-    val claims: Set<String> = emptySet(),
 ) : CredentialRequest {
     override val format: Format = SD_JWT_VC_FORMAT
 }
 
 internal fun Raise<String>.validate(sdJwtVcCredentialRequest: SdJwtVcCredentialRequest, meta: SdJwtVcCredentialConfiguration) {
-    ensure(sdJwtVcCredentialRequest.type == meta.type) { "doctype is ${sdJwtVcCredentialRequest.type} but was expecting ${meta.type}" }
-    if (meta.claims.isEmpty()) {
-        ensure(sdJwtVcCredentialRequest.claims.isEmpty()) { "Requested claims should be empty. " }
-    } else {
-        val expectedAttributeNames = meta.claims.map { it.name }
-        sdJwtVcCredentialRequest.claims.forEach { name ->
-            ensure(name in expectedAttributeNames) { "Unexpected attribute $name" }
-        }
+    ensure(sdJwtVcCredentialRequest.type == meta.type) {
+        "doctype is ${sdJwtVcCredentialRequest.type} but was expecting ${meta.type}"
     }
 }


### PR DESCRIPTION
As per draft15, SD-JWT VC and MSO MDoc Credential Requests no longer contain profile specific properties.

This PR removes `claims` from the related domain classes.