### PR TITLE
Remove `credential_identifiers_supported` from Credential Issuer's Metadata.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
@@ -46,8 +46,6 @@ data class CredentialIssuerMetaDataTO(
     val credentialResponseEncryption: CredentialResponseEncryptionTO? = null,
     @SerialName("batch_credential_issuance")
     val batchCredentialIssuance: BatchCredentialIssuanceTO? = null,
-    @SerialName("credential_identifiers_supported")
-    val credentialIdentifiersSupported: Boolean? = null,
     @SerialName("signed_metadata")
     val signedMetadata: String? = null,
     @SerialName("display")
@@ -104,7 +102,6 @@ private fun CredentialIssuerMetaData.toTransferObject(): CredentialIssuerMetaDat
         BatchCredentialIssuance.NotSupported -> null
         is BatchCredentialIssuance.Supported -> CredentialIssuerMetaDataTO.BatchCredentialIssuanceTO(batchCredentialIssuance.batchSize)
     },
-    credentialIdentifiersSupported = true,
     signedMetadata = null,
     display = display.map { it.toTransferObject() }.takeIf { it.isNotEmpty() },
     credentialConfigurationsSupported = JsonObject(


### PR DESCRIPTION
Closes #299 