### PR TITLE
Add missing `trust_anchor` PID attribute in metadata.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
@@ -196,6 +196,13 @@ val MobilePhoneNumberAttribute = AttributeDetails(
         Locale.ENGLISH to "Mobile Phone Number",
     ),
 )
+val TrustAnchorAttribute = AttributeDetails(
+    name = "trust_anchor",
+    mandatory = false,
+    display = mapOf(
+        Locale.ENGLISH to "Trust Anchor",
+    ),
+)
 
 private val pidAttributes = PidMsoMdocNamespace to listOf(
     FamilyNameAttribute,
@@ -226,6 +233,7 @@ private val pidAttributes = PidMsoMdocNamespace to listOf(
     AgeOver18Attribute,
     AgeInYearsAttribute,
     AgeBirthYearAttribute,
+    TrustAnchorAttribute,
 )
 
 private const val PID_DOCTYPE = "eu.europa.ec.eudi.pid"

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
@@ -68,6 +68,12 @@ internal object Attributes {
         display = mapOf(Locale.ENGLISH to "Age in Years"),
     )
 
+    val LocationStatus = AttributeDetails(
+        name = "location_status",
+        mandatory = false,
+        display = mapOf(Locale.ENGLISH to "Location Status"),
+    )
+
     val pidAttributes: List<AttributeDetails> = listOf(
         OidcFamilyName,
         OidcGivenName,
@@ -91,6 +97,8 @@ internal object Attributes {
         AgeEqualOrOver,
         AgeInYears,
         AgeBirthYear,
+        TrustAnchorAttribute,
+        LocationStatus,
     )
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
@@ -68,12 +68,6 @@ internal object Attributes {
         display = mapOf(Locale.ENGLISH to "Age in Years"),
     )
 
-    val LocationStatus = AttributeDetails(
-        name = "location_status",
-        mandatory = false,
-        display = mapOf(Locale.ENGLISH to "Location Status"),
-    )
-
     val pidAttributes: List<AttributeDetails> = listOf(
         OidcFamilyName,
         OidcGivenName,
@@ -98,7 +92,6 @@ internal object Attributes {
         AgeInYears,
         AgeBirthYear,
         TrustAnchorAttribute,
-        LocationStatus,
     )
 }
 


### PR DESCRIPTION
Add `trust_anchor` to MSO MDoc and SD-JWT VC PID metadata

Supersedes #307 which was closed due to Github not being able to process updates.

Closes #306

