### PR TITLE
Add support for issuing EHIC as SD-JWT VC Compact.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DefaultResolveCredentialRequestByCredentialIdentifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DefaultResolveCredentialRequestByCredentialIdentifier.kt
@@ -17,12 +17,13 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.credential
 
 import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIdentifier
-import eu.europa.ec.eudi.pidissuer.domain.CredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
+import eu.europa.ec.eudi.pidissuer.domain.ResolvedCredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
 import eu.europa.ec.eudi.pidissuer.port.out.credential.ResolveCredentialRequestByCredentialIdentifier
 
-typealias CredentialRequestFactory = (NonEmptyList<UnvalidatedProof>, RequestedResponseEncryption) -> CredentialRequest
+typealias CredentialRequestFactory =
+    (CredentialIdentifier, NonEmptyList<UnvalidatedProof>, RequestedResponseEncryption) -> ResolvedCredentialRequest
 
 class DefaultResolveCredentialRequestByCredentialIdentifier(
     private val factories: Map<CredentialIdentifier, CredentialRequestFactory>,
@@ -32,6 +33,6 @@ class DefaultResolveCredentialRequestByCredentialIdentifier(
         identifier: CredentialIdentifier,
         unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
         credentialResponseEncryption: RequestedResponseEncryption,
-    ): CredentialRequest? =
-        factories[identifier]?.let { factory -> factory(unvalidatedProofs, credentialResponseEncryption) }
+    ): ResolvedCredentialRequest? =
+        factories[identifier]?.let { factory -> factory(identifier, unvalidatedProofs, credentialResponseEncryption) }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/ehic/EncodeEuropeanHealthInsuranceCardInSdJwtVc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/ehic/EncodeEuropeanHealthInsuranceCardInSdJwtVc.kt
@@ -25,11 +25,14 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.signingAlgorithm
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
+import eu.europa.ec.eudi.pidissuer.domain.IntegrityHashAlgorithm
 import eu.europa.ec.eudi.pidissuer.domain.SdJwtVcType
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
 import eu.europa.ec.eudi.pidissuer.port.input.Username
 import eu.europa.ec.eudi.sdjwt.*
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps.asJwsJsonObject
+import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps.serialize
+import eu.europa.ec.eudi.sdjwt.dsl.values.SdJwtObject
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcTypeMetadata
 import kotlinx.serialization.json.*
@@ -40,20 +43,58 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlin.io.encoding.Base64
 
-internal enum class IntegrityHashAlgorithm(val id: String) {
-    SHA_256("sha256"),
-    SHA_384("sha384"),
-    SHA_512("sha512"),
+sealed interface EncodeEuropeanHealthInsuranceCardInSdJwtVc {
+    suspend operator fun invoke(
+        ehic: EuropeanHealthInsuranceCard,
+        holder: Username,
+        holderPublicKey: JWK,
+        dateOfIssuance: ZonedDateTime,
+        dateOfExpiry: ZonedDateTime,
+    ): Either<IssueCredentialError, JsonElement>
+
+    companion object {
+        fun jwsJsonFlattened(
+            digestsHashAlgorithm: HashAlgorithm,
+            issuerSigningKey: IssuerSigningKey,
+            integrityHashAlgorithm: IntegrityHashAlgorithm,
+            vct: SdJwtVcType,
+            credentialIssuerId: CredentialIssuerId,
+            typeMetadata: SdJwtVcTypeMetadata,
+        ): EncodeEuropeanHealthInsuranceCardInSdJwtVc = JwsJsonFlattenedEncoder(
+            digestsHashAlgorithm,
+            issuerSigningKey,
+            integrityHashAlgorithm,
+            vct,
+            credentialIssuerId,
+            typeMetadata,
+        )
+
+        fun compact(
+            digestsHashAlgorithm: HashAlgorithm,
+            issuerSigningKey: IssuerSigningKey,
+            integrityHashAlgorithm: IntegrityHashAlgorithm,
+            vct: SdJwtVcType,
+            credentialIssuerId: CredentialIssuerId,
+            typeMetadata: SdJwtVcTypeMetadata,
+        ): EncodeEuropeanHealthInsuranceCardInSdJwtVc = CompactEncoder(
+            digestsHashAlgorithm,
+            issuerSigningKey,
+            integrityHashAlgorithm,
+            vct,
+            credentialIssuerId,
+            typeMetadata,
+        )
+    }
 }
 
-internal class EncodeEuropeanHealthInsuranceCardInSdJwtVc(
+private class JwsJsonFlattenedEncoder(
     digestsHashAlgorithm: HashAlgorithm,
     issuerSigningKey: IssuerSigningKey,
     private val integrityHashAlgorithm: IntegrityHashAlgorithm,
     private val vct: SdJwtVcType,
     private val credentialIssuerId: CredentialIssuerId,
     private val typeMetadata: SdJwtVcTypeMetadata,
-) {
+) : EncodeEuropeanHealthInsuranceCardInSdJwtVc {
     init {
         require(typeMetadata.vct.value == vct.value)
     }
@@ -68,17 +109,13 @@ internal class EncodeEuropeanHealthInsuranceCardInSdJwtVc(
         }
     }
 
-    private val formatter: DateTimeFormatter by lazy {
-        DateTimeFormatter.ISO_LOCAL_DATE
-    }
-
-    suspend operator fun invoke(
+    override suspend operator fun invoke(
         ehic: EuropeanHealthInsuranceCard,
         holder: Username,
         holderPublicKey: JWK,
         dateOfIssuance: ZonedDateTime,
         dateOfExpiry: ZonedDateTime,
-    ): Either<IssueCredentialError, JsonObject> = either {
+    ): Either<IssueCredentialError, JsonElement> = either {
         require(dateOfExpiry >= dateOfIssuance)
 
         val (vctm, vctmIntegrity) = run {
@@ -87,41 +124,17 @@ internal class EncodeEuropeanHealthInsuranceCardInSdJwtVc(
             val vctmIntegiry = "${integrityHashAlgorithm.id}-${Base64.encode(integrityHashAlgorithm.digest(encodedTypeMetadata))}"
             vctm to vctmIntegiry
         }
-
-        val spec = sdJwt {
-            claim(SdJwtVcSpec.VCT, vct.value)
-            claim(SdJwtVcSpec.VCT_INTEGRITY, vctmIntegrity)
-            claim(RFC7519.JWT_ID, UUID.randomUUID().toString())
-            claim(RFC7519.SUBJECT, holder)
-            claim(RFC7519.ISSUER, credentialIssuerId.externalForm)
-            claim(RFC7519.ISSUED_AT, dateOfIssuance.toEpochSecond())
-            cnf(holderPublicKey)
-            claim(RFC7519.EXPIRATION_TIME, dateOfExpiry.toEpochSecond())
-            claim(RFC7519.NOT_BEFORE, dateOfIssuance.toEpochSecond())
-            sdClaim(EuropeanHealthInsuranceCardClaims.PersonalAdministrativeNumber.name, ehic.personalAdministrativeNumber.value)
-            objClaim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.attribute.name) {
-                claim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.Id.name, ehic.issuingAuthority.id.value)
-                claim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.Name.name, ehic.issuingAuthority.name.value)
-            }
-            claim(EuropeanHealthInsuranceCardClaims.IssuingCountry.name, ehic.issuingCountry.value)
-            claim(EuropeanHealthInsuranceCardClaims.DateOfExpiry.name, formatter.format(dateOfExpiry.withZoneSameInstant(ZoneOffset.UTC)))
-            claim(
-                EuropeanHealthInsuranceCardClaims.DateOfIssuance.name,
-                formatter.format(dateOfIssuance.withZoneSameInstant(ZoneOffset.UTC)),
+        val spec =
+            sdJwt(
+                vct,
+                vctmIntegrity,
+                ehic,
+                holder,
+                holderPublicKey,
+                credentialIssuerId,
+                dateOfIssuance = dateOfIssuance,
+                dateOfExpiry = dateOfExpiry,
             )
-            objClaim(EuropeanHealthInsuranceCardClaims.AuthenticSource.attribute.name) {
-                claim(EuropeanHealthInsuranceCardClaims.AuthenticSource.Id.name, ehic.authenticSource.id.value)
-                claim(EuropeanHealthInsuranceCardClaims.AuthenticSource.Name.name, ehic.authenticSource.name.value)
-            }
-            ehic.endingDate?.let {
-                claim(EuropeanHealthInsuranceCardClaims.EndingDate.name, formatter.format(it.withZoneSameInstant(ZoneOffset.UTC)))
-            }
-            ehic.startingDate?.let {
-                claim(EuropeanHealthInsuranceCardClaims.StartingDate.name, formatter.format(it.withZoneSameInstant(ZoneOffset.UTC)))
-            }
-            sdClaim(EuropeanHealthInsuranceCardClaims.DocumentNumber.name, ehic.documentNumber.value)
-        }
-
         val sdJwt =
             catch({ issuer.issue(spec).getOrThrow() }) {
                 raise(IssueCredentialError.Unexpected("Unable to create SD-JWT VC", it))
@@ -153,5 +166,111 @@ private fun IntegrityHashAlgorithm.digest(input: String): ByteArray {
         IntegrityHashAlgorithm.SHA_256 -> MessageDigest.getInstance("SHA-256").digest(encodedInput)
         IntegrityHashAlgorithm.SHA_384 -> MessageDigest.getInstance("SHA-384").digest(encodedInput)
         IntegrityHashAlgorithm.SHA_512 -> MessageDigest.getInstance("SHA-512").digest(encodedInput)
+    }
+}
+
+private class CompactEncoder(
+    digestsHashAlgorithm: HashAlgorithm,
+    issuerSigningKey: IssuerSigningKey,
+    private val integrityHashAlgorithm: IntegrityHashAlgorithm,
+    private val vct: SdJwtVcType,
+    private val credentialIssuerId: CredentialIssuerId,
+    private val typeMetadata: SdJwtVcTypeMetadata,
+) : EncodeEuropeanHealthInsuranceCardInSdJwtVc {
+    init {
+        require(typeMetadata.vct.value == vct.value)
+    }
+
+    private val issuer: SdJwtIssuer<SignedJWT> by lazy {
+        val factory = SdJwtFactory(digestsHashAlgorithm)
+        val signer = ECDSASigner(issuerSigningKey.key)
+        val vctm = run {
+            val encodedTypeMetadata = Json.encodeToString(typeMetadata)
+            Base64UrlNoPadding.encode(encodedTypeMetadata.encodeToByteArray())
+        }
+        NimbusSdJwtOps.issuer(factory, signer, issuerSigningKey.signingAlgorithm) {
+            type(JOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT))
+            keyID(issuerSigningKey.key.keyID)
+            x509CertChain(issuerSigningKey.key.x509CertChain)
+            customParam("vctm", listOf(vctm))
+        }
+    }
+
+    override suspend operator fun invoke(
+        ehic: EuropeanHealthInsuranceCard,
+        holder: Username,
+        holderPublicKey: JWK,
+        dateOfIssuance: ZonedDateTime,
+        dateOfExpiry: ZonedDateTime,
+    ): Either<IssueCredentialError, JsonElement> = either {
+        require(dateOfExpiry >= dateOfIssuance)
+
+        val vctmIntegrity = run {
+            val encodedTypeMetadata = Json.encodeToString(typeMetadata)
+            "${integrityHashAlgorithm.id}-${Base64.encode(integrityHashAlgorithm.digest(encodedTypeMetadata))}"
+        }
+        val spec =
+            sdJwt(
+                vct,
+                vctmIntegrity,
+                ehic,
+                holder,
+                holderPublicKey,
+                credentialIssuerId,
+                dateOfIssuance = dateOfIssuance,
+                dateOfExpiry = dateOfExpiry,
+            )
+        val sdJwt =
+            catch({ issuer.issue(spec).getOrThrow() }) {
+                raise(IssueCredentialError.Unexpected("Unable to create SD-JWT VC", it))
+            }
+        JsonPrimitive(sdJwt.serialize())
+    }
+}
+
+private fun sdJwt(
+    vct: SdJwtVcType,
+    vctmIntegrity: String,
+    ehic: EuropeanHealthInsuranceCard,
+    holder: Username,
+    holderPublicKey: JWK,
+    credentialIssuerId: CredentialIssuerId,
+    dateOfIssuance: ZonedDateTime,
+    dateOfExpiry: ZonedDateTime,
+): SdJwtObject {
+    val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+    return sdJwt {
+        claim(SdJwtVcSpec.VCT, vct.value)
+        claim(SdJwtVcSpec.VCT_INTEGRITY, vctmIntegrity)
+        claim(RFC7519.JWT_ID, UUID.randomUUID().toString())
+        claim(RFC7519.SUBJECT, holder)
+        claim(RFC7519.ISSUER, credentialIssuerId.externalForm)
+        claim(RFC7519.ISSUED_AT, dateOfIssuance.toEpochSecond())
+        cnf(holderPublicKey)
+        claim(RFC7519.EXPIRATION_TIME, dateOfExpiry.toEpochSecond())
+        claim(RFC7519.NOT_BEFORE, dateOfIssuance.toEpochSecond())
+        sdClaim(EuropeanHealthInsuranceCardClaims.PersonalAdministrativeNumber.name, ehic.personalAdministrativeNumber.value)
+        objClaim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.attribute.name) {
+            claim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.Id.name, ehic.issuingAuthority.id.value)
+            claim(EuropeanHealthInsuranceCardClaims.IssuingAuthority.Name.name, ehic.issuingAuthority.name.value)
+        }
+        claim(EuropeanHealthInsuranceCardClaims.IssuingCountry.name, ehic.issuingCountry.value)
+        claim(EuropeanHealthInsuranceCardClaims.DateOfExpiry.name, formatter.format(dateOfExpiry.withZoneSameInstant(ZoneOffset.UTC)))
+        claim(
+            EuropeanHealthInsuranceCardClaims.DateOfIssuance.name,
+            formatter.format(dateOfIssuance.withZoneSameInstant(ZoneOffset.UTC)),
+        )
+        objClaim(EuropeanHealthInsuranceCardClaims.AuthenticSource.attribute.name) {
+            claim(EuropeanHealthInsuranceCardClaims.AuthenticSource.Id.name, ehic.authenticSource.id.value)
+            claim(EuropeanHealthInsuranceCardClaims.AuthenticSource.Name.name, ehic.authenticSource.name.value)
+        }
+        ehic.endingDate?.let {
+            claim(EuropeanHealthInsuranceCardClaims.EndingDate.name, formatter.format(it.withZoneSameInstant(ZoneOffset.UTC)))
+        }
+        ehic.startingDate?.let {
+            claim(EuropeanHealthInsuranceCardClaims.StartingDate.name, formatter.format(it.withZoneSameInstant(ZoneOffset.UTC)))
+        }
+        sdClaim(EuropeanHealthInsuranceCardClaims.DocumentNumber.name, ehic.documentNumber.value)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
@@ -176,10 +176,14 @@ internal object SdJwtVcPidClaims {
 
 private fun pidDocType(version: Int): String = "urn:eudi:pid:$version"
 
+internal val SdJwtVcPidVct: SdJwtVcType = SdJwtVcType(pidDocType(1))
+
+internal val SdJwtVcPidCredentialConfigurationId: CredentialConfigurationId = CredentialConfigurationId(PidSdJwtVcScope.value)
+
 fun pidSdJwtVcV1(signingAlgorithm: JWSAlgorithm): SdJwtVcCredentialConfiguration =
     SdJwtVcCredentialConfiguration(
-        id = CredentialConfigurationId(PidSdJwtVcScope.value),
-        type = SdJwtVcType(pidDocType(1)),
+        id = SdJwtVcPidCredentialConfigurationId,
+        type = SdJwtVcPidVct,
         display = pidDisplay,
         claims = SdJwtVcPidClaims.all(),
         cryptographicBindingMethodsSupported = nonEmptySetOf(CryptographicBindingMethod.Jwk),

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialConfiguration.kt
@@ -90,7 +90,7 @@ value class ProofTypesSupported private constructor(val values: Set<ProofType>) 
  */
 sealed interface CredentialConfiguration {
     val id: CredentialConfigurationId
-    val scope: Scope?
+    val scope: Scope
     val display: List<CredentialDisplay>
     val cryptographicBindingMethodsSupported: Set<CryptographicBindingMethod>
     val credentialSigningAlgorithmsSupported: Set<JWSAlgorithm>

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -130,6 +130,11 @@ data class CredentialIssuerMetaData(
         require(displayLocales.size == displayLocales.distinct().size) {
             "only one display object can be configured per locale"
         }
+
+        val credentialConfigurationIds = specificCredentialIssuers.map { it.supportedCredential.id }
+        require(credentialConfigurationIds.size == credentialConfigurationIds.distinct().size) {
+            "credential configuration ids must be unique"
+        }
     }
 
     val credentialConfigurationsSupported: List<CredentialConfiguration>

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialRequest.kt
@@ -172,3 +172,12 @@ fun Raise<String>.assertIsSupported(credentialRequest: CredentialRequest, meta: 
         }
     }
 }
+
+/**
+ * A resolved Credential Request
+ */
+data class ResolvedCredentialRequest(
+    val credentialConfigurationId: CredentialConfigurationId,
+    val credentialRequest: CredentialRequest,
+    val credentialIdentifier: CredentialIdentifier?,
+)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/JwtVcJsonProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/JwtVcJsonProfile.kt
@@ -30,7 +30,7 @@ val JWT_VS_JSON_FORMAT = Format(JWT_VS_JSON_FORMAT_VALUE)
  */
 data class JwtVcJsonCredentialConfiguration(
     override val id: CredentialConfigurationId,
-    override val scope: Scope? = null,
+    override val scope: Scope,
     override val cryptographicBindingMethodsSupported: Set<CryptographicBindingMethod>,
     override val credentialSigningAlgorithmsSupported: Set<JWSAlgorithm>,
     override val display: List<CredentialDisplay>,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
@@ -53,7 +53,7 @@ data class MsoMdocCredentialConfiguration(
     val docType: MsoDocType,
     override val cryptographicBindingMethodsSupported: Set<CryptographicBindingMethod>,
     override val credentialSigningAlgorithmsSupported: Set<JWSAlgorithm>,
-    override val scope: Scope? = null,
+    override val scope: Scope,
     override val display: List<CredentialDisplay> = emptyList(),
     val claims: List<ClaimDefinition> = emptyList(),
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/SdJwtVcProfile.kt
@@ -34,7 +34,7 @@ value class SdJwtVcType(val value: String)
 data class SdJwtVcCredentialConfiguration(
     override val id: CredentialConfigurationId,
     val type: SdJwtVcType,
-    override val scope: Scope? = null,
+    override val scope: Scope,
     override val cryptographicBindingMethodsSupported: NonEmptySet<CryptographicBindingMethod>,
     override val credentialSigningAlgorithmsSupported: NonEmptySet<JWSAlgorithm>,
     override val display: List<CredentialDisplay>,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
@@ -145,3 +145,9 @@ value class CredentialIdentifier(val value: String)
  * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/">https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/</a>
  */
 data class StatusListToken(val statusList: URI, val index: UInt)
+
+enum class IntegrityHashAlgorithm(val id: String) {
+    SHA_256("sha256"),
+    SHA_384("sha384"),
+    SHA_512("sha512"),
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import org.slf4j.LoggerFactory
 
@@ -131,7 +130,7 @@ sealed interface IssueCredentialError {
      */
     data class InvalidEncryptionParameters(val error: Throwable) : IssueCredentialError
 
-    data class WrongScope(val expected: Scope) : IssueCredentialError
+    data class WrongScope(val expected: List<Scope>) : IssueCredentialError
 
     data class Unexpected(val msg: String, val cause: Throwable? = null) : IssueCredentialError
 }
@@ -271,7 +270,7 @@ class IssueCredential(
                 credentialRequestTO.credentialConfigurationId
                     ?: credentialRequestTO.credentialIdentifier
             log.info("Handling issuance request for $credentialConfigurationIdOrCredentialIdentifier..")
-            val(request, issued) =
+            val (request, issued) =
                 services().issueCredential(authorizationContext, credentialRequestTO)
             successResponse(request, issued)
         }.getOrElse { error ->
@@ -314,16 +313,22 @@ private class Services(
                     credentialIssuerMetadata.batchCredentialIssuance,
                     credentialIssuerMetadata.credentialConfigurationsSupported,
                 )
-            val (request, credentialIdentifier) =
+            val request =
                 when (unresolvedRequest) {
                     is UnresolvedCredentialRequest.ByCredentialConfigurationId ->
-                        unresolvedRequest.credentialRequest to null
+                        ResolvedCredentialRequest.ByCredentialConfigurationId(
+                            unresolvedRequest.credentialConfigurationId,
+                            unresolvedRequest.credentialRequest,
+                        )
 
                     is UnresolvedCredentialRequest.ByCredentialIdentifier ->
-                        resolve(unresolvedRequest) to unresolvedRequest.credentialIdentifier
+                        ResolvedCredentialRequest.ByCredentialIdentifier(
+                            unresolvedRequest.credentialIdentifier,
+                            resolve(unresolvedRequest),
+                        )
                 }
-            val issued = issue(authorizationContext, request, credentialIdentifier)
-            request to issued
+            val issued = issue(authorizationContext, request)
+            request.credentialRequest to issued
         }
 
         private suspend fun resolve(
@@ -341,27 +346,58 @@ private class Services(
 
         private suspend fun issue(
             authorizationContext: AuthorizationContext,
-            credentialRequest: CredentialRequest,
-            credentialIdentifier: CredentialIdentifier?,
+            resolvedCredentialRequest: ResolvedCredentialRequest,
         ): CredentialResponse {
-            val issueSpecificCredential = specificIssuerFor(credentialRequest)
-            val expectedScope = checkNotNull(issueSpecificCredential.supportedCredential.scope)
-            ensure(authorizationContext.scopes.contains(expectedScope)) { WrongScope(expectedScope) }
-            return issueSpecificCredential(authorizationContext, credentialRequest, credentialIdentifier).bind()
+            val issueSpecificCredential = specificIssuerFor(authorizationContext, resolvedCredentialRequest)
+            return issueSpecificCredential(
+                authorizationContext,
+                resolvedCredentialRequest.credentialRequest,
+                resolvedCredentialRequest.credentialIdentifierOrNull,
+            ).bind()
         }
 
-        private fun specificIssuerFor(credentialRequest: CredentialRequest): IssueSpecificCredential {
-            val specificIssuer = credentialIssuerMetadata.specificCredentialIssuers
-                .find { issuer ->
-                    either { assertIsSupported(credentialRequest, issuer.supportedCredential) }.isRight()
+        private fun specificIssuerFor(
+            authorizationContext: AuthorizationContext,
+            resolvedCredentialRequest: ResolvedCredentialRequest,
+        ): IssueSpecificCredential {
+            val credentialRequest = resolvedCredentialRequest.credentialRequest
+            val specificIssuers = credentialIssuerMetadata.specificCredentialIssuers
+                .filter { issuer ->
+                    either {
+                        assertIsSupported(credentialRequest, issuer.supportedCredential)
+                    }.isRight()
                 }
-            if (specificIssuer == null) {
+            ensure(specificIssuers.isNotEmpty()) {
                 val types = when (credentialRequest) {
                     is MsoMdocCredentialRequest -> listOf(credentialRequest.docType)
                     is SdJwtVcCredentialRequest -> listOf(credentialRequest.type).map { it.value }
                 }
-                raise(UnsupportedCredentialType(credentialRequest.format, types))
+                UnsupportedCredentialType(credentialRequest.format, types)
             }
+
+            val expectedScopes = specificIssuers.map { issuer -> issuer.supportedCredential.scope }
+            ensure(expectedScopes.any { it in authorizationContext.scopes }) {
+                WrongScope(expectedScopes)
+            }
+
+            val specificIssuer = when (resolvedCredentialRequest) {
+                is ResolvedCredentialRequest.ByCredentialConfigurationId -> {
+                    specificIssuers.find { issuer ->
+                        issuer.supportedCredential.scope in authorizationContext.scopes &&
+                            issuer.supportedCredential.id == resolvedCredentialRequest.credentialConfigurationId
+                    }
+                }
+
+                is ResolvedCredentialRequest.ByCredentialIdentifier -> {
+                    specificIssuers.find { issuer ->
+                        issuer.supportedCredential.scope in authorizationContext.scopes
+                    }
+                }
+            }
+            ensureNotNull(specificIssuer) {
+                Unexpected("The Credential Request does not contain enough information to determine the Credential to issue")
+            }
+
             return specificIssuer
         }
     }
@@ -377,7 +413,10 @@ private sealed interface UnresolvedCredentialRequest {
     /**
      * A Credential Request placed by Credential Configuration Id.
      */
-    data class ByCredentialConfigurationId(val credentialRequest: CredentialRequest) : UnresolvedCredentialRequest
+    data class ByCredentialConfigurationId(
+        val credentialConfigurationId: CredentialConfigurationId,
+        val credentialRequest: CredentialRequest,
+    ) : UnresolvedCredentialRequest
 
     /**
      * A Credential Request placed by Credential Identifier.
@@ -388,6 +427,36 @@ private sealed interface UnresolvedCredentialRequest {
         val credentialResponseEncryption: RequestedResponseEncryption,
     ) : UnresolvedCredentialRequest
 }
+
+/**
+ * A resolved Credential Request.
+ */
+private sealed interface ResolvedCredentialRequest {
+
+    val credentialRequest: CredentialRequest
+
+    /**
+     * A Credential Request placed by Credential Configuration Id.
+     */
+    data class ByCredentialConfigurationId(
+        val credentialConfigurationId: CredentialConfigurationId,
+        override val credentialRequest: CredentialRequest,
+    ) : ResolvedCredentialRequest
+
+    /**
+     * A Credential Request placed by Credential Identifier.
+     */
+    data class ByCredentialIdentifier(
+        val credentialIdentifier: CredentialIdentifier,
+        override val credentialRequest: CredentialRequest,
+    ) : ResolvedCredentialRequest
+}
+
+private val ResolvedCredentialRequest.credentialIdentifierOrNull: CredentialIdentifier?
+    get() = when (this) {
+        is ResolvedCredentialRequest.ByCredentialConfigurationId -> null
+        is ResolvedCredentialRequest.ByCredentialIdentifier -> credentialIdentifier
+    }
 
 private val BatchCredentialIssuance.maxProofsSupported: Int
     get() = when (this) {
@@ -453,7 +522,7 @@ private interface Validations : Raise<IssueCredentialError> {
                         is SdJwtVcCredentialConfiguration -> credentialConfiguration.credentialRequest(proofs, credentialResponseEncryption)
                         is JwtVcJsonCredentialConfiguration -> raise(UnsupportedCredentialType(format = JWT_VS_JSON_FORMAT))
                     }
-                    UnresolvedCredentialRequest.ByCredentialConfigurationId(credentialRequest)
+                    UnresolvedCredentialRequest.ByCredentialConfigurationId(credentialConfigurationId, credentialRequest)
                 } ?: raise(UnsupportedCredentialConfigurationId(credentialConfigurationId))
 
         fun credentialRequestByCredentialIdentifier(credentialIdentifier: String): UnresolvedCredentialRequest.ByCredentialIdentifier =
@@ -604,7 +673,8 @@ private fun IssueCredentialError.toTO(): IssueCredentialResponse.FailedTO {
             CredentialErrorTypeTo.INVALID_ENCRYPTION_PARAMETERS to "Invalid Credential Response Encryption Parameters"
 
         is WrongScope ->
-            CredentialErrorTypeTo.INVALID_CREDENTIAL_REQUEST to "Wrong scope. Expecting $expected"
+            CredentialErrorTypeTo.INVALID_CREDENTIAL_REQUEST to
+                "Wrong scope. Expecting one of ${expected.joinToString(separator = ", ", transform = { it.value })}"
 
         is Unexpected ->
             CredentialErrorTypeTo.INVALID_CREDENTIAL_REQUEST to "$msg${cause?.message?.let { " : $it" } ?: ""}"

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/ResolveCredentialRequestByCredentialIdentifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/ResolveCredentialRequestByCredentialIdentifier.kt
@@ -17,8 +17,8 @@ package eu.europa.ec.eudi.pidissuer.port.out.credential
 
 import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIdentifier
-import eu.europa.ec.eudi.pidissuer.domain.CredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.RequestedResponseEncryption
+import eu.europa.ec.eudi.pidissuer.domain.ResolvedCredentialRequest
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
 
 /**
@@ -31,5 +31,5 @@ fun interface ResolveCredentialRequestByCredentialIdentifier {
         identifier: CredentialIdentifier,
         unvalidatedProofs: NonEmptyList<UnvalidatedProof>,
         credentialResponseEncryption: RequestedResponseEncryption,
-    ): CredentialRequest?
+    ): ResolvedCredentialRequest?
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -271,7 +271,7 @@ internal class WalletApiEncryptionOptionalTest : BaseWalletApiTest() {
 
         val error = assertIs<IssueCredentialResponse.FailedTO>(response)
         assertEquals(CredentialErrorTypeTo.INVALID_CREDENTIAL_REQUEST, error.type)
-        assertEquals("Wrong scope. Expecting one of ${PidMsoMdocScope.value}", error.errorDescription)
+        assertEquals("Wrong scope. Expected ${PidMsoMdocScope.value}", error.errorDescription)
     }
 
     /**

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -271,7 +271,7 @@ internal class WalletApiEncryptionOptionalTest : BaseWalletApiTest() {
 
         val error = assertIs<IssueCredentialResponse.FailedTO>(response)
         assertEquals(CredentialErrorTypeTo.INVALID_CREDENTIAL_REQUEST, error.type)
-        assertEquals("Wrong scope. Expecting $PidMsoMdocScope", error.errorDescription)
+        assertEquals("Wrong scope. Expecting one of ${PidMsoMdocScope.value}", error.errorDescription)
     }
 
     /**


### PR DESCRIPTION
This PR adds support for issuing EHIC as an SD-JWT VC serialized using compact serialization.

Additionally, this PR augments the Specific Issuer matching mechanism to also consider any Credential Configuration Id that was provided in the Credential Request. If multiple Specific Issuers are matched, an error is raised and Issuance is cancelled.