### PR TITLE
Fix Json Schema for `nationalities`. The shared array can be empty.

### DIFF
--- a/src/main/resources/vct/pid_arf18.json
+++ b/src/main/resources/vct/pid_arf18.json
@@ -591,7 +591,7 @@
           "type": "string",
           "minLength": 1
         },
-        "minItems": 1
+        "minItems": 0
       },
       "address": {
         "type": "object",


### PR DESCRIPTION
Closes #373 