### PR TITLE
Various improvements and parallelization of batch issuance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ set this to `FRAMEWORK`.
 Possible values: `FRAMEWORK`, `NONE`  
 Default value: `FRAMEWORK`  
 
+Variable: `SPRING_WEBFLUX_CODECS_MAX_IN_MEMORY_SIZE`  
+Description: Configure a limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated. Uses Spring Framework's DataSize notation.         
+Default value: `1MB`
+
 Variable: `ISSUER_PUBLICURL`  
 Description: URL the PID Issuer application is accessible from  
 Default value: `http://localhost:8080`

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -15,12 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer
 
-import arrow.core.Either
-import arrow.core.NonEmptySet
-import arrow.core.getOrElse
-import arrow.core.recover
-import arrow.core.some
-import arrow.core.toNonEmptySetOrNull
+import arrow.core.*
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.jwk.*
@@ -113,6 +108,7 @@ import org.springframework.security.web.server.authentication.HttpStatusServerEn
 import org.springframework.security.web.server.authentication.ServerAuthenticationEntryPointFailureHandler
 import org.springframework.security.web.server.authorization.HttpStatusServerAccessDeniedHandler
 import org.springframework.security.web.server.authorization.ServerWebExchangeDelegatingServerAccessDeniedHandler
+import org.springframework.util.unit.DataSize
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.netty.http.client.HttpClient
@@ -842,6 +838,9 @@ fun beans(clock: Clock) = beans {
             it.defaultCodecs().kotlinSerializationJsonDecoder(KotlinSerializationJsonDecoder(json))
             it.defaultCodecs().kotlinSerializationJsonEncoder(KotlinSerializationJsonEncoder(json))
             it.defaultCodecs().enableLoggingRequestDetails(true)
+
+            val maxInMemorySize = DataSize.parse(env.getProperty("spring.webflux.codecs.max-in-memory-size", "1MB"))
+            it.defaultCodecs().maxInMemorySize(maxInMemorySize.toBytes().toInt())
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -693,7 +693,7 @@ fun beans(clock: Clock) = beans {
         fun Scope.springConvention() = "SCOPE_$value"
         val metaData = ref<CredentialIssuerMetaData>()
         val scopes = metaData.credentialConfigurationsSupported
-            .mapNotNull { it.scope?.springConvention() }
+            .map { it.scope.springConvention() }
             .distinct()
         val http = ref<ServerHttpSecurity>()
         http {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -319,20 +319,16 @@ fun beans(clock: Clock) = beans {
         )
     }
     bean<EncodePidInCbor>(isLazyInit = true) {
-        log.info("Using internal encoder to encode PID in CBOR")
         val issuerSigningKey = ref<IssuerSigningKey>()
-        val duration = env.duration("issuer.pid.mso_mdoc.encoder.duration")?.toKotlinDuration() ?: 30.days
-        DefaultEncodePidInCbor(clock, issuerSigningKey, duration)
+        DefaultEncodePidInCbor(issuerSigningKey)
     }
 
     bean {
         GetMobileDrivingLicenceDataMock()
     }
     bean<EncodeMobileDrivingLicenceInCbor>(isLazyInit = true) {
-        log.info("Using internal encoder to encode mDL in CBOR")
         val issuerSigningKey = ref<IssuerSigningKey>()
-        val duration = env.duration("issuer.mdl.mso_mdoc.encoder.duration")?.toKotlinDuration() ?: 5.days
-        DefaultEncodeMobileDrivingLicenceInCbor(clock, issuerSigningKey, duration)
+        DefaultEncodeMobileDrivingLicenceInCbor(issuerSigningKey)
     }
 
     bean(::DefaultGenerateQrCode)
@@ -460,6 +456,7 @@ fun beans(clock: Clock) = beans {
             credentialResponseEncryption = env.credentialResponseEncryption(),
             specificCredentialIssuers = buildList {
                 if (enableMsoMdocPid) {
+                    val duration = env.duration("issuer.pid.mso_mdoc.encoder.duration")?.toKotlinDuration() ?: 30.days
                     val issueMsoMdocPid = IssueMsoMdocPid(
                         getPidData = ref(),
                         encodePidInCbor = ref(),
@@ -467,6 +464,7 @@ fun beans(clock: Clock) = beans {
                             ?: true,
                         generateNotificationId = ref(),
                         clock = clock,
+                        validityDuration = duration,
                         storeIssuedCredentials = ref(),
                         validateProofs = ref(),
                     )
@@ -510,12 +508,14 @@ fun beans(clock: Clock) = beans {
                 }
 
                 if (enableMobileDrivingLicence) {
+                    val duration = env.duration("issuer.mdl.mso_mdoc.encoder.duration")?.toKotlinDuration() ?: 5.days
                     val mdlIssuer = IssueMobileDrivingLicence(
                         getMobileDrivingLicenceData = ref(),
                         encodeMobileDrivingLicenceInCbor = ref(),
                         notificationsEnabled = env.getProperty<Boolean>("issuer.mdl.notifications.enabled") ?: true,
                         generateNotificationId = ref(),
                         clock = clock,
+                        validityDuration = duration,
                         storeIssuedCredentials = ref(),
                         validateProofs = ref(),
                     )

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/EncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/EncodeMobileDrivingLicenceInCbor.kt
@@ -18,11 +18,17 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.mdl
 import arrow.core.Either
 import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
+import kotlinx.datetime.Instant
 
 /**
  * Encodes a Mobile Driving Licence in CBOR format.
  */
 fun interface EncodeMobileDrivingLicenceInCbor {
 
-    suspend operator fun invoke(licence: MobileDrivingLicence, holderKey: ECKey): Either<IssueCredentialError.Unexpected, String>
+    suspend operator fun invoke(
+        licence: MobileDrivingLicence,
+        holderKey: ECKey,
+        issuedAt: Instant,
+        expiresAt: Instant,
+    ): Either<IssueCredentialError.Unexpected, String>
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
@@ -26,8 +26,6 @@ import id.walt.mdoc.dataelement.MapElement
 import id.walt.mdoc.doc.MDocBuilder
 import id.walt.mdoc.mso.DeviceKeyInfo
 import id.walt.mdoc.mso.ValidityInfo
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.datetime.toKotlinInstant
 import java.time.Clock
 import kotlin.io.encoding.Base64
@@ -49,15 +47,14 @@ internal class MsoMdocSigner<in Credential>(
         issuerSigningKey.cryptoProvider()
     }
 
-    suspend fun sign(credential: Credential, deviceKey: ECKey): String =
-        withContext(Dispatchers.IO) {
-            val validityInfo = validityInfo()
-            val deviceKeyInfo = deviceKeyInfo(deviceKey)
-            val mdoc = MDocBuilder(docType)
-                .apply { usage(credential) }
-                .sign(validityInfo, deviceKeyInfo, issuerCryptoProvider, issuerSigningKey.key.keyID)
-            Base64.UrlSafe.encode(mdoc.issuerSigned.toMapElement().toCBOR())
-        }
+    fun sign(credential: Credential, deviceKey: ECKey): String {
+        val validityInfo = validityInfo()
+        val deviceKeyInfo = deviceKeyInfo(deviceKey)
+        val mdoc = MDocBuilder(docType)
+            .apply { usage(credential) }
+            .sign(validityInfo, deviceKeyInfo, issuerCryptoProvider, issuerSigningKey.key.keyID)
+        return Base64.UrlSafe.encode(mdoc.issuerSigned.toMapElement().toCBOR())
+    }
 
     private fun validityInfo(): ValidityInfo {
         val signedAt = clock.instant().toKotlinInstant()

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
@@ -22,21 +22,13 @@ import eu.europa.ec.eudi.pidissuer.domain.ClaimDefinition
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
+import kotlinx.datetime.Instant
 import kotlinx.datetime.toKotlinLocalDate
-import java.time.Clock
-import kotlin.time.Duration
 
-internal class DefaultEncodePidInCbor(
-    clock: Clock,
-    issuerSigningKey:
-        IssuerSigningKey,
-    validityDuration: Duration,
-) : EncodePidInCbor {
+internal class DefaultEncodePidInCbor(issuerSigningKey: IssuerSigningKey) : EncodePidInCbor {
 
     private val signer = MsoMdocSigner<Pair<Pid, PidMetaData>>(
-        clock = clock,
         issuerSigningKey = issuerSigningKey,
-        validityDuration = validityDuration,
         docType = PidMsoMdocV1.docType,
     ) { (pid, pidMetaData) ->
         addItemsToSign(pid)
@@ -47,7 +39,9 @@ internal class DefaultEncodePidInCbor(
         pid: Pid,
         pidMetaData: PidMetaData,
         holderKey: ECKey,
-    ): String = signer.sign(pid to pidMetaData, holderKey)
+        issuedAt: Instant,
+        expiresAt: Instant,
+    ): String = signer.sign(pid to pidMetaData, holderKey, issuedAt = issuedAt, expiresAt = expiresAt)
 }
 
 private fun MDocBuilder.addItemsToSign(pid: Pid) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInCbor.kt
@@ -16,7 +16,14 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.pid
 
 import com.nimbusds.jose.jwk.ECKey
+import kotlinx.datetime.Instant
 
 fun interface EncodePidInCbor {
-    suspend operator fun invoke(pid: Pid, pidMetaData: PidMetaData, holderKey: ECKey): String
+    suspend operator fun invoke(
+        pid: Pid,
+        pidMetaData: PidMetaData,
+        holderKey: ECKey,
+        issuedAt: Instant,
+        expiresAt: Instant,
+    ): String
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetCredentialIssuerMetaData.kt
@@ -165,7 +165,7 @@ private fun credentialMetaDataJson(
     batchCredentialIssuance: BatchCredentialIssuance,
 ): JsonObject = buildJsonObject {
     put("format", d.format().value)
-    d.scope?.value?.let { put("scope", it) }
+    put("scope", d.scope.value)
     d.cryptographicBindingMethodsSupported.takeIf { it.isNotEmpty() }
         ?.let { cryptographicBindingMethodsSupported ->
             putJsonArray("cryptographic_binding_methods_supported") {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.webflux.static-path-pattern=/public/**
 spring.webflux.webjars-path-pattern=/webjars/**
 spring.messages.basename=i18n/messages
 server.forward-headers-strategy=framework
+spring.webflux.codecs.max-in-memory-size=1MB
 
 #
 # Issuer options

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -161,7 +161,7 @@ internal class BaseWalletApiTest {
 
         @Bean
         @Primary
-        fun encodePidInCbor(): EncodePidInCbor = EncodePidInCbor { _, _, _ -> "PID" }
+        fun encodePidInCbor(): EncodePidInCbor = EncodePidInCbor { _, _, _, _, _ -> "PID" }
     }
 }
 


### PR DESCRIPTION
* Fixes various issues concerning encoder ergonomics. Previously encoders contained side effects. Now encoders are pure and accept as parameters, the data to be encoded.
* Specific Credential Issuers now perform all side effects, and pass required data to encoders.
* Batch issuance has been parallelized using Arrow's `parMap`