### PR TITLE
Drop Keycloak Admin Client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,9 +68,6 @@ dependencies {
     implementation(libs.nimbus.oauth2) {
         because("To support DPoP")
     }
-    implementation(libs.keycloak.admin.client) {
-        because("To be able to fetch user attributes")
-    }
     implementation(libs.waltid.mdoc.credentials) {
         because("To sign CBOR credentials")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ dependencyCheck = "12.1.1"
 bootstrap = "5.3.3"
 multiformat = "1.1.0"
 resultMonad = "1.4.0"
-keycloak = "26.0.4"
 waltid = "0.11.0"
 uri-kmp = "0.0.19"
 zxing = "3.5.3"
@@ -34,10 +33,8 @@ eudi-sdjwt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-sdjwt-kt", version.ref =
 bouncy-castle = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle" }
 bootstrap = { module = "org.webjars:bootstrap", version.ref = "bootstrap" }
 tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
-
 multiformat = { module = "org.erwinkok.multiformat:multiformat", version.ref = "multiformat" }
 result-monad = { module = "org.erwinkok.result:result-monad", version.ref = "resultMonad" }
-keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 waltid-mdoc-credentials = { module = "id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm", version.ref = "waltid" }
 uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 zxing = { module = "com.google.zxing:javase", version.ref = "zxing" }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/qr/DefaultGenerateQrCode.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/qr/DefaultGenerateQrCode.kt
@@ -25,7 +25,7 @@ import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import eu.europa.ec.eudi.pidissuer.port.out.qr.Dimensions
 import eu.europa.ec.eudi.pidissuer.port.out.qr.Format
 import eu.europa.ec.eudi.pidissuer.port.out.qr.GenerateQqCode
-import org.apache.commons.io.output.ByteArrayOutputStream
+import java.io.ByteArrayOutputStream
 import java.net.URI
 
 /**


### PR DESCRIPTION
This PR drops the dependency on Keycloak Admin Client.
We only use a single API, that can be easily implemented using WebClient instead.