### PR TITLE
Release/0.6.0 - Support Key Attestation in JWT Proofs and attestation proof type 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024m
 
 group=eu.europa.ec.eudi
-version=0.5.3-SNAPSHOT
+version=0.6.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.gradle.skipCompile=true


### PR DESCRIPTION
Closes #381 