### PR TITLE
Enable passkeys support in Keycloak

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -6,12 +6,12 @@ networks:
 
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.1.4-0
+    image: quay.io/keycloak/keycloak:26.3.2-0
     container_name: keycloak
     command:
       - start-dev
       - --import-realm
-      - --features=dpop
+      - --features=dpop,passkeys
     environment:
       - KC_PROXY_HEADERS=xforwarded
       - KC_HTTP_ENABLED=true

--- a/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
+++ b/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
@@ -459,30 +459,37 @@
     "totpAppFreeOTPName",
     "totpAppGoogleName"
   ],
-  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicyRpEntityName": "https://localhost/idp",
   "webAuthnPolicySignatureAlgorithms": [
-    "ES256"
+    "ES256",
+    "ES384",
+    "ES512"
   ],
-  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyRpId": "localhost",
   "webAuthnPolicyAttestationConveyancePreference": "not specified",
   "webAuthnPolicyAuthenticatorAttachment": "not specified",
   "webAuthnPolicyRequireResidentKey": "not specified",
-  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "preferred",
   "webAuthnPolicyCreateTimeout": 0,
   "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyAcceptableAaguids": [],
-  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "https://localhost/idp",
   "webAuthnPolicyPasswordlessSignatureAlgorithms": [
-    "ES256"
+    "ES256",
+    "ES384",
+    "ES512"
   ],
-  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessRpId": "localhost",
   "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
   "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
   "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
-  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "preferred",
   "webAuthnPolicyPasswordlessCreateTimeout": 0,
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "webAuthnPolicyPasswordlessPasskeysEnabled": true,
   "scopeMappings": [
     {
       "clientScope": "eu.europa.ec.eudi.pid_vc_sd_jwt",


### PR DESCRIPTION
This PR:

1. Updates Keycloak to v26.1.4-0
2. Enables `passkeys` feature
3. Updates `pid-issuer-realm` realm configuration to enable passkeys - *passkey registration is optional*

With the above:
* During new account creation, passkey registration is not required
* Passkey registration, both for new and existing accounts, can be done in Account Management -> Account Security -> Signing In (e.g. https://dev.authenticate.eudiw.dev/realms/pid-issuer-realm/account/account-security/signing-in). Here a user can register one or more passkeys
* During sign in, below the username/password form, a new button appears which when clicked, prompts the user to sign in using a registered passkey

> [!NOTE]
> https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-openid4vci-kt examples are not affected

Closes #387 