### PR TITLE
Add metadata URL inside the landing page

### DIFF
--- a/src/main/resources/templates/generate-credentials-offer-form.html
+++ b/src/main/resources/templates/generate-credentials-offer-form.html
@@ -74,6 +74,26 @@
                 </button>
             </div>
         </div>
+        <div class="row">
+            <h4> Known Metadata URL locations </h4>
+            <table class="table table-hover" style='width:80%'>
+                <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Location</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr th:if="${metadata.empty}">
+                        <td colspan="2"> No Metadata Endpoints Available </td>
+                    </tr>
+                    <tr th:each="metadata : ${metadata}">
+                        <td><span th:text="${metadata.key}"> Type </span></td>
+                        <td><a th:href="${metadata.value}" th:text="${metadata.value}"> URL </a> </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </main>
 <script type="application/javascript"


### PR DESCRIPTION
A map is created containing all the metadata urls that are available from the issuer.
Currently supported:
- VCI Credential Issuer Metadata
- JWT VC Issuer Metadata
- Type Metadata for PID
- Authorization Server Metadata

Closes #417 