### PR TITLE
Upgrade Kotlin and various libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,10 +71,10 @@ dependencies {
     implementation(libs.waltid.mdoc.credentials) {
         because("To sign CBOR credentials")
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2") {
+    implementation(libs.kotlinx.datetime) {
         because("required by walt.id")
     }
-    implementation("com.augustcellars.cose:cose-java:1.1.0") {
+    implementation(libs.cose.java) {
         because("required by walt.id")
     }
     implementation(libs.uri.kmp) {
@@ -101,7 +101,7 @@ kotlin {
     }
 
     compilerOptions {
-        apiVersion = KotlinVersion.KOTLIN_2_0
+        apiVersion = KotlinVersion.KOTLIN_2_1
         freeCompilerArgs.addAll(
             "-Xjsr305=strict",
             "-Xconsistent-data-class-copy-visibility",
@@ -110,6 +110,7 @@ kotlin {
             "kotlinx.serialization.ExperimentalSerializationApi",
             "kotlin.io.encoding.ExperimentalEncodingApi",
             "kotlin.contracts.ExperimentalContracts",
+            "kotlin.time.ExperimentalTime",
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-coroutines = "1.10.1"
-kotlin = "2.0.21"
+coroutines = "1.10.2"
+kotlin = "2.1.21"
 arrow = "2.0.1"
 springboot = "3.4.6"
 spotless = "7.0.2"
 java = "17"
-kotlinxSerialization = "1.8.0"
+kotlinxSerialization = "1.8.1"
 ktlint = "0.50.0"
 nimbusJoseJwt = "10.0.2"
 nimbusOAuth2 = "11.23.1"
-eudiSdJwt = "0.14.0"
+eudiSdJwt = "0.16.0"
 bouncyCastle = "1.80"
 dependencyCheck = "12.1.1"
 bootstrap = "5.3.3"
@@ -20,7 +20,8 @@ uri-kmp = "0.0.19"
 zxing = "3.5.3"
 tink = "1.17.0"
 kover = "0.9.1"
-
+cose-java = "1.1.0"
+kotlinx-datetime = "0.7.1-0.6.x-compat"
 
 [libraries]
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
@@ -38,6 +39,8 @@ result-monad = { module = "org.erwinkok.result:result-monad", version.ref = "res
 waltid-mdoc-credentials = { module = "id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm", version.ref = "waltid" }
 uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 zxing = { module = "com.google.zxing:javase", version.ref = "zxing" }
+cose-java = { module = "com.augustcellars.cose:cose-java", version.ref = "cose-java" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
@@ -26,8 +26,8 @@ import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.Unexpected
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
-import kotlinx.datetime.Instant
 import kotlinx.datetime.toKotlinLocalDate
+import kotlin.time.Instant
 
 class DefaultEncodeMobileDrivingLicenceInCbor(issuerSigningKey: IssuerSigningKey) : EncodeMobileDrivingLicenceInCbor {
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/EncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/EncodeMobileDrivingLicenceInCbor.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.mdl
 import arrow.core.Either
 import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Encodes a Mobile Driving Licence in CBOR format.

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -33,12 +33,12 @@ import eu.europa.ec.eudi.pidissuer.port.out.IssueSpecificCredential
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.Dispatchers
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.*
 import kotlin.time.Duration
+import kotlin.time.toKotlinInstant
 
 val MobileDrivingLicenceV1Scope: Scope = Scope(mdlDocType(1u))
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
@@ -26,8 +26,9 @@ import id.walt.mdoc.dataelement.MapElement
 import id.walt.mdoc.doc.MDocBuilder
 import id.walt.mdoc.mso.DeviceKeyInfo
 import id.walt.mdoc.mso.ValidityInfo
-import kotlinx.datetime.Instant
+import kotlinx.datetime.toDeprecatedInstant
 import kotlin.io.encoding.Base64
+import kotlin.time.Instant
 
 internal class MsoMdocSigner<in Credential>(
     private val issuerSigningKey: IssuerSigningKey,
@@ -45,7 +46,12 @@ internal class MsoMdocSigner<in Credential>(
         expiresAt: Instant,
     ): String {
         require(expiresAt >= issuedAt) { "expiresAt must greater or equal to issuedAt" }
-        val validityInfo = ValidityInfo(signed = issuedAt, validFrom = issuedAt, validUntil = expiresAt, expectedUpdate = null)
+        val validityInfo = ValidityInfo(
+            signed = issuedAt.toDeprecatedInstant(),
+            validFrom = issuedAt.toDeprecatedInstant(),
+            validUntil = expiresAt.toDeprecatedInstant(),
+            expectedUpdate = null,
+        )
         val deviceKeyInfo = deviceKeyInfo(deviceKey)
         val mdoc = MDocBuilder(docType)
             .apply { usage(credential) }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
@@ -22,8 +22,8 @@ import eu.europa.ec.eudi.pidissuer.domain.ClaimDefinition
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
-import kotlinx.datetime.Instant
 import kotlinx.datetime.toKotlinLocalDate
+import kotlin.time.Instant
 
 internal class DefaultEncodePidInCbor(issuerSigningKey: IssuerSigningKey) : EncodePidInCbor {
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInCbor.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.pid
 
 import com.nimbusds.jose.jwk.ECKey
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 fun interface EncodePidInCbor {
     suspend operator fun invoke(

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
@@ -33,13 +33,13 @@ import eu.europa.ec.eudi.pidissuer.port.out.IssueSpecificCredential
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.Dispatchers
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.*
 import java.util.Locale.ENGLISH
 import kotlin.time.Duration
+import kotlin.time.toKotlinInstant
 
 val PidMsoMdocScope: Scope = Scope("eu.europa.ec.eudi.pid_mso_mdoc")
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/IssueCredential.kt
@@ -339,7 +339,6 @@ private class Services(
                     unresolvedRequest.credentialResponseEncryption,
                 )
                 ensureNotNull(resolvedRequest) { InvalidCredentialIdentifier(unresolvedRequest.credentialIdentifier) }
-                resolvedRequest
             }.bind()
 
         private suspend fun issue(


### PR DESCRIPTION
This PR upgrades:

1. Kotlin to 2.1.21
2. KotlinX Datetime to 0.7.1-0.6.x-compat
3. SD-JWT to 0.16.0
4. KotlinX Coroutines to 1.10.2
5. KotlinX Serialization to 1.8.1