### PR TITLE
Replace java.time with kotlin.time

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPNonce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPNonce.kt
@@ -18,8 +18,8 @@ package eu.europa.ec.eudi.pidissuer.adapter.input.web.security
 import com.nimbusds.jose.JWSAlgorithm
 import eu.europa.ec.eudi.pidissuer.port.out.credential.GenerateNonce
 import eu.europa.ec.eudi.pidissuer.port.out.credential.VerifyNonce
-import java.time.Duration
-import java.time.Instant
+import kotlin.time.Duration
+import kotlin.time.Instant
 
 /**
  * Properties for configuring DPoP.
@@ -32,8 +32,8 @@ data class DPoPConfigurationProperties(
 ) {
     init {
         require(JWSAlgorithm.Family.SIGNATURE.containsAll(algorithms)) { "'algorithms' contains invalid values" }
-        require(!proofMaxAge.isZero && !proofMaxAge.isNegative) { "'proofMaxAge' must be positive" }
-        require(!cachePurgeInterval.isZero && !cachePurgeInterval.isNegative) { "'cachePurgeInterval' must be positive" }
+        require(proofMaxAge.isPositive()) { "'proofMaxAge' must be positive" }
+        require(cachePurgeInterval.isPositive()) { "'cachePurgeInterval' must be positive" }
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPNonceWebFilter.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPNonceWebFilter.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.eudi.pidissuer.adapter.input.web.security
 import org.springframework.web.server.CoWebFilter
 import org.springframework.web.server.CoWebFilterChain
 import org.springframework.web.server.ServerWebExchange
-import java.time.Clock
+import kotlin.time.Clock
 
 /**
  * [CoWebFilter] that generates a new DPoP Nonce for DPoP authenticated web requests and explicitly configured paths.
@@ -31,7 +31,7 @@ class DPoPNonceWebFilter(
     override suspend fun filter(exchange: ServerWebExchange, chain: CoWebFilterChain) {
         val request = exchange.request
         if (request.path.pathWithinApplication().value() in paths) {
-            val newDPoPNonce = dpopNonce.generateDPoPNonce(clock.instant())
+            val newDPoPNonce = dpopNonce.generateDPoPNonce(clock.now())
             val response = exchange.response
             response.headers["DPoP-Nonce"] = newDPoPNonce
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPTokenReactiveAuthenticationManager.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPTokenReactiveAuthenticationManager.kt
@@ -36,8 +36,8 @@ import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNam
 import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException
 import org.springframework.security.oauth2.server.resource.introspection.SpringReactiveOpaqueTokenIntrospector
 import reactor.core.publisher.Mono
-import java.time.Clock
-import java.time.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * [ReactiveAuthenticationManager] implementing DPoP authentication.
@@ -61,7 +61,7 @@ class DPoPTokenReactiveAuthenticationManager(
                     val principal = introspect(authentication.accessToken)
                     val issuer = principal.issuer()
                     val thumbprint = principal.jwkThumbprint()
-                    val dpopNonce = dpopNonce.verifyDPoPNonce(authentication.dpop.nonce(), clock.instant())
+                    val dpopNonce = dpopNonce.verifyDPoPNonce(authentication.dpop.nonce(), clock.now())
                     verify(authentication, issuer, thumbprint, dpopNonce)
                     authentication.authenticate(principal)
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPTokenServerAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/security/DPoPTokenServerAuthenticationEntryPoint.kt
@@ -25,7 +25,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.web.server.ServerAuthenticationEntryPoint
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
-import java.time.Clock
+import kotlin.time.Clock
 
 /**
  * [ServerAuthenticationEntryPoint] implementation used to commence authentication of a protected resource using DPoP.
@@ -68,7 +68,7 @@ class DPoPTokenServerAuthenticationEntryPoint(
                 when (error) {
                     is DPoPTokenError.UseDPoPNonce -> {
                         check(dpopNonce is DPoPNoncePolicy.Enforcing)
-                        dpopNonce.generateDPoPNonce(clock.instant())
+                        dpopNonce.generateDPoPNonce(clock.now())
                     }
                     else -> null
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DecryptNonceWithNimbusAndVerify.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/DecryptNonceWithNimbusAndVerify.kt
@@ -30,7 +30,8 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.port.out.credential.VerifyNonce
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.time.Instant
+import kotlin.time.Instant
+import kotlin.time.toKotlinInstant
 
 /**
  * Decrypts an [EncryptedJWT] using Nimbus and verifies it's still active.
@@ -67,7 +68,7 @@ internal class DecryptNonceWithNimbusAndVerify(
                 val jwt = EncryptedJWT.parse(it)
                 val claimSet = processor.process(jwt, null)
                 val expiresAt = requireNotNull(claimSet.expirationTime) { "expirationTime is required" }
-                at < expiresAt.toInstant()
+                at < expiresAt.toInstant().toKotlinInstant()
             }.getOrElse { false }
         } ?: false
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/GenerateNonceAndEncryptWithNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/credential/GenerateNonceAndEncryptWithNimbus.kt
@@ -24,9 +24,10 @@ import com.nimbusds.openid.connect.sdk.Nonce
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.port.out.credential.GenerateNonce
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.time.Duration
-import java.time.Instant
 import java.util.*
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
 
 /**
  * Generates a Nonce and encrypts it as a [EncryptedJWT] with Nimbus.
@@ -54,8 +55,8 @@ internal class GenerateNonceAndEncryptWithNimbus(
                     issuer(issuer.externalForm)
                     audience(issuer.externalForm)
                     claim("nonce", generator())
-                    issueTime(Date.from(generatedAt))
-                    expirationTime(Date.from(expiresAt))
+                    issueTime(Date.from(generatedAt.toJavaInstant()))
+                    expirationTime(Date.from(expiresAt.toJavaInstant()))
                 }
                 .build(),
         ).apply {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptResponseWithNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptResponseWithNimbus.kt
@@ -36,8 +36,9 @@ import eu.europa.ec.eudi.pidissuer.port.out.jose.EncryptDeferredResponse
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
-import java.time.Clock
-import java.util.*
+import java.util.Date
+import kotlin.time.Clock
+import kotlin.time.toJavaInstant
 
 /**
  * Implementation of [EncryptDeferredResponse] using Nimbus.
@@ -99,7 +100,7 @@ private class EncryptResponse(
         val baseClaims = JWTClaimsSet.parse(claimsJson)
         val jwtClaimSet = JWTClaimsSet.Builder(baseClaims)
             .issuer(issuer.externalForm)
-            .issueTime(Date.from(clock.instant()))
+            .issueTime(Date.from(clock.now().toJavaInstant()))
             .apply(customize)
             .build()
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateAttestationProof.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateAttestationProof.kt
@@ -19,7 +19,7 @@ import arrow.core.Either
 import eu.europa.ec.eudi.pidissuer.adapter.out.util.getOrThrow
 import eu.europa.ec.eudi.pidissuer.domain.*
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
-import java.time.Instant
+import kotlin.time.Instant
 
 internal class ValidateAttestationProof(
     private val verifyKeyAttestation: VerifyKeyAttestation,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateJwtProof.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateJwtProof.kt
@@ -36,9 +36,9 @@ import eu.europa.ec.eudi.pidissuer.adapter.out.util.getOrThrow
 import eu.europa.ec.eudi.pidissuer.domain.*
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
 import java.security.interfaces.ECPublicKey
-import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
+import kotlin.time.Instant
 
 /**
  * Validator for JWT Proofs.

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofs.kt
@@ -28,7 +28,7 @@ import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.*
 import eu.europa.ec.eudi.pidissuer.port.out.credential.VerifyNonce
 import kotlinx.coroutines.coroutineScope
-import java.time.Instant
+import kotlin.time.Instant
 
 /**
  * Validators for Proofs.

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/VerifyKeyAttestation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/VerifyKeyAttestation.kt
@@ -39,10 +39,10 @@ import eu.europa.ec.eudi.pidissuer.domain.OpenId4VciSpec
 import eu.europa.ec.eudi.pidissuer.port.out.credential.VerifyNonce
 import java.net.URI
 import java.security.cert.*
-import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
+import kotlin.time.Instant
 
 internal val SkipRevocation: PKIXParameters.() -> Unit = { isRevocationEnabled = false }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/IssueMobileDrivingLicence.kt
@@ -35,10 +35,9 @@ import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
-import java.time.Clock
 import java.util.*
+import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.toKotlinInstant
 
 val MobileDrivingLicenceV1Scope: Scope = Scope(mdlDocType(1u))
 
@@ -348,7 +347,7 @@ internal class IssueMobileDrivingLicence(
     ): Either<IssueCredentialError, CredentialResponse> = either {
         log.info("Issuing mDL")
         val holderKeys = with(jwkExtensions()) {
-            validateProofs(request.unvalidatedProofs, supportedCredential, clock.instant()).bind()
+            validateProofs(request.unvalidatedProofs, supportedCredential, clock.now()).bind()
                 .map { jwk -> jwk.toECKeyOrFail { InvalidProof("Only EC Key is supported") } }
         }
         val licence = getMobileDrivingLicenceData(authorizationContext).bind()
@@ -356,7 +355,7 @@ internal class IssueMobileDrivingLicence(
             IssueCredentialError.Unexpected("Unable to fetch mDL data")
         }
 
-        val issuedAt = clock.instant().toKotlinInstant()
+        val issuedAt = clock.now()
         val expiresAt = issuedAt + validityDuration
 
         val issuedCredentials = holderKeys.parMap(Dispatchers.Default, 4) { holderKey ->
@@ -378,7 +377,7 @@ internal class IssueMobileDrivingLicence(
                     "${familyName.latin.value} ${givenName.latin.value}"
                 },
                 holderPublicKeys = holderKeys,
-                issuedAt = clock.instant(),
+                issuedAt = clock.now(),
                 notificationId = notificationId,
             ),
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
@@ -23,10 +23,8 @@ import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreDeferredCredential
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.slf4j.LoggerFactory
-import java.time.Clock
-import java.time.Instant
-import kotlin.time.toJavaInstant
-import kotlin.time.toKotlinInstant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * Represents the state of the deferred issuance. Holds the response encryption as specified in initial request
@@ -51,11 +49,11 @@ class InMemoryDeferredCredentialRepository(
                 val deferredPersist = data[transactionId]
                 when {
                     deferredPersist == null -> LoadDeferredCredentialResult.InvalidTransactionId
-                    clock.instant() > deferredPersist.notIssuedBefore -> LoadDeferredCredentialResult.Found(deferredPersist.issued)
+                    clock.now() > deferredPersist.notIssuedBefore -> LoadDeferredCredentialResult.Found(deferredPersist.issued)
                     else -> LoadDeferredCredentialResult.IssuancePending(
                         CredentialResponse.Deferred(
                             transactionId,
-                            deferredPersist.notIssuedBefore.toKotlinInstant() - clock.instant().toKotlinInstant(),
+                            deferredPersist.notIssuedBefore - clock.now(),
                         ),
                     )
                 }
@@ -68,7 +66,7 @@ class InMemoryDeferredCredentialRepository(
                 if (data.containsKey(transactionId)) {
                     require(data[transactionId] == null) { "Oops!! $transactionId already exists" }
                 }
-                data[transactionId] = DeferredState(credential, notIssuedBefore.toJavaInstant())
+                data[transactionId] = DeferredState(credential, notIssuedBefore)
                 log.info("Stored $transactionId -> $credential ")
             }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/DefaultEncodePidInCbor.kt
@@ -22,7 +22,6 @@ import eu.europa.ec.eudi.pidissuer.domain.ClaimDefinition
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
-import kotlinx.datetime.toKotlinLocalDate
 import kotlin.time.Instant
 
 internal class DefaultEncodePidInCbor(issuerSigningKey: IssuerSigningKey) : EncodePidInCbor {
@@ -47,7 +46,7 @@ internal class DefaultEncodePidInCbor(issuerSigningKey: IssuerSigningKey) : Enco
 private fun MDocBuilder.addItemsToSign(pid: Pid) {
     addItemToSign(MsoMdocPidClaims.FamilyName, pid.familyName.value.toDataElement())
     addItemToSign(MsoMdocPidClaims.GivenName, pid.givenName.value.toDataElement())
-    addItemToSign(MsoMdocPidClaims.BirthDate, pid.birthDate.toKotlinLocalDate().toDataElement())
+    addItemToSign(MsoMdocPidClaims.BirthDate, pid.birthDate.toDataElement())
     val birthPlace = pid.birthPlace?.let { birthPlace ->
         listOfNotNull(birthPlace.locality?.value, birthPlace.region?.value, birthPlace.country?.value)
             .joinToString(separator = ", ")
@@ -81,7 +80,7 @@ private fun MDocBuilder.addItemsToSign(pid: Pid) {
 
 private fun MDocBuilder.addItemsToSign(metaData: PidMetaData) {
     metaData.personalAdministrativeNumber?.let { addItemToSign(MsoMdocPidClaims.PersonalAdministrativeNumber, it.value.toDataElement()) }
-    addItemToSign(MsoMdocPidClaims.ExpiryDate, metaData.expiryDate.toKotlinLocalDate().toDataElement())
+    addItemToSign(MsoMdocPidClaims.ExpiryDate, metaData.expiryDate.toDataElement())
     when (val issuingAuthority = metaData.issuingAuthority) {
         is IssuingAuthority.MemberState ->
             addItemToSign(MsoMdocPidClaims.IssuingAuthority, issuingAuthority.code.value.toDataElement())
@@ -91,7 +90,7 @@ private fun MDocBuilder.addItemsToSign(metaData: PidMetaData) {
     addItemToSign(MsoMdocPidClaims.IssuingCountry, metaData.issuingCountry.value.toDataElement())
     metaData.documentNumber?.let { addItemToSign(MsoMdocPidClaims.DocumentNumber, it.value.toDataElement()) }
     metaData.issuingJurisdiction?.let { addItemToSign(MsoMdocPidClaims.IssuingJurisdiction, it.toDataElement()) }
-    metaData.issuanceDate?.let { addItemToSign(MsoMdocPidClaims.IssuanceDate, it.toKotlinLocalDate().toDataElement()) }
+    metaData.issuanceDate?.let { addItemToSign(MsoMdocPidClaims.IssuanceDate, it.toDataElement()) }
 }
 
 private fun MDocBuilder.addItemToSign(claim: ClaimDefinition, value: DataElement) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInSdJwtVc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInSdJwtVc.kt
@@ -42,8 +42,8 @@ import kotlinx.serialization.json.JsonElement
 import org.slf4j.LoggerFactory
 import java.net.URL
 import java.security.cert.X509Certificate
-import java.time.Instant
 import kotlin.io.encoding.Base64
+import kotlin.time.Instant
 
 private val log = LoggerFactory.getLogger(EncodePidInSdJwtVc::class.java)
 
@@ -132,9 +132,9 @@ private fun selectivelyDisclosed(
         // Always disclosed claims
         //
         claim(RFC7519.ISSUER, credentialIssuerId.externalForm)
-        claim(RFC7519.ISSUED_AT, iat.epochSecond)
-        nbf?.let { claim(RFC7519.NOT_BEFORE, it.epochSecond) }
-        claim(RFC7519.EXPIRATION_TIME, exp.epochSecond)
+        claim(RFC7519.ISSUED_AT, iat.epochSeconds)
+        nbf?.let { claim(RFC7519.NOT_BEFORE, it.epochSeconds) }
+        claim(RFC7519.EXPIRATION_TIME, exp.epochSeconds)
         cnf(holderPubKey)
         claim(SdJwtVcSpec.VCT, vct.value)
         statusListToken?.let {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueMsoMdocPid.kt
@@ -35,11 +35,9 @@ import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredentials
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
-import java.time.Clock
-import java.util.*
 import java.util.Locale.ENGLISH
+import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.toKotlinInstant
 
 val PidMsoMdocScope: Scope = Scope("eu.europa.ec.eudi.pid_mso_mdoc")
 
@@ -325,7 +323,7 @@ internal class IssueMsoMdocPid(
     ): Either<IssueCredentialError, CredentialResponse> = either {
         log.info("Handling issuance request ...")
         val holderPubKeys = with(jwkExtensions()) {
-            validateProofs(request.unvalidatedProofs, supportedCredential, clock.instant())
+            validateProofs(request.unvalidatedProofs, supportedCredential, clock.now())
                 .bind()
                 .map { jwk -> jwk.toECKeyOrFail { InvalidProof("Only EC Key is supported") } }
         }
@@ -333,7 +331,7 @@ internal class IssueMsoMdocPid(
         val pidData = getPidData(authorizationContext)
         val (pid, pidMetaData) = pidData.bind()
 
-        val issuedAt = clock.instant().toKotlinInstant()
+        val issuedAt = clock.now()
         val expiresAt = issuedAt + validityDuration
 
         val issuedCredentials = holderPubKeys.parMap(Dispatchers.Default, 4) { holderKey ->
@@ -358,7 +356,7 @@ internal class IssueMsoMdocPid(
                     "${familyName.value} ${givenName.value}"
                 },
                 holderPublicKeys = holderPubKeys,
-                issuedAt = clock.instant(),
+                issuedAt = clock.now(),
                 notificationId = notificationId,
             ),
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/Pid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/Pid.kt
@@ -16,8 +16,8 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.pid
 
 import arrow.core.NonEmptyList
+import kotlinx.datetime.LocalDate
 import java.net.URI
-import java.time.LocalDate
 import java.time.Year
 import java.util.regex.Pattern
 
@@ -210,7 +210,7 @@ data class PidMetaData(
 ) {
     init {
         issuanceDate?.let {
-            require(it.isBefore(expiryDate)) { "Issuance date should be before expiry date" }
+            require(it < expiryDate) { "Issuance date should be before expiry date" }
         }
 
         if (issuingAuthority is IssuingAuthority.MemberState) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Types.kt
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
-import java.time.Instant
 import java.util.*
+import kotlin.time.Instant
 
 private val logHttpsUrl = LoggerFactory.getLogger(HttpsUrl::class.java)
 
@@ -36,7 +36,7 @@ value class HttpsUrl private constructor(val value: URL) {
         fun of(url: String): HttpsUrl? =
             try {
                 of(URL(url))
-            } catch (e: MalformedURLException) {
+            } catch (_: MalformedURLException) {
                 null
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/HandleNonceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/input/HandleNonceRequest.kt
@@ -19,8 +19,8 @@ import eu.europa.ec.eudi.pidissuer.port.out.credential.GenerateNonce
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.time.Clock
-import java.time.Duration
+import kotlin.time.Clock
+import kotlin.time.Duration
 
 /**
  * Response to a Nonce Request.
@@ -38,5 +38,5 @@ internal class HandleNonceRequest(
     private val cNonceExpiresIn: Duration,
     private val generateNonce: GenerateNonce,
 ) {
-    suspend operator fun invoke(): NonceResponseTO = NonceResponseTO(generateNonce(clock.instant(), cNonceExpiresIn))
+    suspend operator fun invoke(): NonceResponseTO = NonceResponseTO(generateNonce(clock.now(), cNonceExpiresIn))
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/IssueSpecificCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/IssueSpecificCredential.kt
@@ -24,11 +24,9 @@ import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateTransactionId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreDeferredCredential
 import org.slf4j.LoggerFactory
-import java.time.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
-import kotlin.time.toKotlinInstant
 
 interface IssueSpecificCredential {
 
@@ -88,7 +86,7 @@ private class DeferredIssuer(
         require(credentialResponse is CredentialResponse.Issued) { "Actual issuer should return issued credentials" }
 
         val transactionId = generateTransactionId()
-        storeDeferredCredential.invoke(transactionId, credentialResponse, clock.instant().plus(interval.toJavaDuration()).toKotlinInstant())
+        storeDeferredCredential.invoke(transactionId, credentialResponse, clock.now().plus(interval))
         CredentialResponse.Deferred(transactionId, interval).also {
             log.info("Repackaged $credentialResponse  as $it")
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/GenerateNonce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/GenerateNonce.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.pidissuer.port.out.credential
 
-import java.time.Duration
-import java.time.Instant
+import kotlin.time.Duration
+import kotlin.time.Instant
 
 /**
  * Generates a new Nonce that expires after a specific [Duration].

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/VerifyNonce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/port/out/credential/VerifyNonce.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.port.out.credential
 
-import java.time.Instant
+import kotlin.time.Instant
 
 /**
  * Verifies a Nonce value is valid at a specific [Instant].


### PR DESCRIPTION
There is also a small change to PidIssuerApplication.kt that 
changes `client.get` metadata to flow instead of java's main.

Tests are under change aswel.

Closes  #426

