### PR TITLE
Improve `loadJwkFromKeystore`.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -1076,6 +1076,16 @@ private fun loadJwkFromKeystore(environment: Environment, prefix: String): JWK {
             else -> "$prefix.$property"
         }
 
+    fun X509Certificate.isSelfSigned(): Boolean =
+        subjectX500Principal == issuerX500Principal && runCatching {
+            verify(publicKey)
+            true
+        }.getOrElse { false }
+
+    fun List<X509Certificate>.dropRootCA(): List<X509Certificate> =
+        if (size > 1 && last().isSelfSigned()) dropLast(1)
+        else this
+
     fun JWK.withCertificateChain(chain: List<X509Certificate>): JWK {
         require(this.parsedX509CertChain.isNotEmpty()) { "jwk must have a leaf certificate" }
         require(chain.isNotEmpty()) { "chain cannot be empty" }
@@ -1083,7 +1093,7 @@ private fun loadJwkFromKeystore(environment: Environment, prefix: String): JWK {
             "leaf certificate of provided chain does not match leaf certificate of jwk"
         }
 
-        val encodedChain = chain.map { Base64.encode(it.encoded) }
+        val encodedChain = chain.dropRootCA().map { Base64.encode(it.encoded) }
         return when (this) {
             is RSAKey -> RSAKey.Builder(this).x509CertChain(encodedChain).build()
             is ECKey -> ECKey.Builder(this).x509CertChain(encodedChain).build()


### PR DESCRIPTION
When `loadJwkFromKeystore` loads an x5c chain from a keystore, it associates the loaded jwk with the x5c chain as it was loaded from the keystore.
the x5c chain though might also contain the Root CA, which is not to be included in the `x5c` of issued credentials.

This PR updates `loadJwkFromKeystore` so that when the loaded x5c chain contains more than 1 certificates, if the last certificate is the Root CA, it is dropped.

To check whether the last certificate of the x5c chain a Root CA, we check if it is self-signed, i.e.:
1. check if subject == issuer
2. check if the ceritificate signature validates using the public key of the certificate