### PR TITLE
Update SD-JWT VC encoding of PID.PlaceOfBirth and align with MSO MDoc

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/oauth/Claims.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/oauth/Claims.kt
@@ -177,7 +177,7 @@ data class OidcAssurancePlaceOfBirth(
 
         val Locality = ClaimDefinition(
             path = ClaimPath.claim(NAME).claim("locality"),
-            mandatory = false,
+            mandatory = true,
             display = mapOf(Locale.ENGLISH to "Locality"),
         )
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInSdJwtVc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/EncodePidInSdJwtVc.kt
@@ -26,6 +26,7 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.certificate
 import eu.europa.ec.eudi.pidissuer.adapter.out.oauth.OidcAddressClaim
+import eu.europa.ec.eudi.pidissuer.adapter.out.oauth.OidcAssurancePlaceOfBirth
 import eu.europa.ec.eudi.pidissuer.adapter.out.signingAlgorithm
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.domain.SdJwtVcType
@@ -153,10 +154,10 @@ private fun selectivelyDisclosed(
         sdClaim(SdJwtVcPidClaims.GivenName.name, pid.givenName.value)
         sdClaim(SdJwtVcPidClaims.BirthDate.name, pid.birthDate.toString())
         with(pid.placeOfBirth) {
-            sdObjClaim(SdJwtVcPidClaims.PlaceOfBirth.attribute.name) {
-                country?.let { claim(SdJwtVcPidClaims.PlaceOfBirth.Country.name, it.value) }
-                region?.let { claim(SdJwtVcPidClaims.PlaceOfBirth.Region.name, it.value) }
-                locality?.let { claim(SdJwtVcPidClaims.PlaceOfBirth.Locality.name, it.value) }
+            sdObjClaim(OidcAssurancePlaceOfBirth.NAME) {
+                country?.let { claim(OidcAssurancePlaceOfBirth.Country.name, it.value) }
+                region?.let { claim(OidcAssurancePlaceOfBirth.Region.name, it.value) }
+                locality?.let { claim(OidcAssurancePlaceOfBirth.Locality.name, it.value) }
             }
         }
         sdArrClaim(SdJwtVcPidClaims.Nationalities.name) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/IssueSdJwtVcPid.kt
@@ -51,7 +51,10 @@ internal object SdJwtVcPidClaims {
     val BirthDate = OidcBirthDate
     val BirthFamilyName = OidcAssuranceBirthFamilyName
     val BirthGivenName = OidcAssuranceBirthGivenName
-    val PlaceOfBirth = OidcAssurancePlaceOfBirth
+    val PlaceOfBirth = OidcAssurancePlaceOfBirth.attribute.copy(
+        mandatory = true,
+        nested = emptyList(),
+    )
     val Address = OidcAddressClaim
     val Sex = ClaimDefinition(
         path = ClaimPath.claim("sex"),
@@ -128,7 +131,7 @@ internal object SdJwtVcPidClaims {
         FamilyName,
         GivenName,
         BirthDate,
-        PlaceOfBirth.attribute,
+        PlaceOfBirth,
         Nationalities,
         Address.attribute,
         PersonalAdministrativeNumber,

--- a/src/main/resources/vct/pid_v1.4.json
+++ b/src/main/resources/vct/pid_v1.4.json
@@ -107,45 +107,6 @@
     },
     {
       "path": [
-        "place_of_birth",
-        "locality"
-      ],
-      "display": [
-        {
-          "lang": "en",
-          "label": "Locality"
-        }
-      ],
-      "sd": "never"
-    },
-    {
-      "path": [
-        "place_of_birth",
-        "region"
-      ],
-      "display": [
-        {
-          "lang": "en",
-          "label": "Region"
-        }
-      ],
-      "sd": "never"
-    },
-    {
-      "path": [
-        "place_of_birth",
-        "country"
-      ],
-      "display": [
-        {
-          "lang": "en",
-          "label": "Country"
-        }
-      ],
-      "sd": "never"
-    },
-    {
-      "path": [
         "nationalities"
       ],
       "display": [


### PR DESCRIPTION
This PR updates the SD-JWT VC encoding of PID.PlaceOfBirth to be aligned with MSO MDoc, i.e. a top-level selectively disclosable object with never selectively disclosable nested properties.

This allows Place Of Birth to be presented using the same behavior, regardless of encoding format.