### PR TITLE
Handle gracefully legacy users that have no Nationlity set

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -245,7 +245,7 @@ class GetPidDataFromKeyCloak(
             } else null
         } ?: PlaceOfBirth.NotKnown
 
-        val nationality = userInfo.nationality?.let { IsoCountry(it) } ?: IsoCountry.UTOPIA
+        val nationality = userInfo.nationality?.let { IsoCountry(it) } ?: issuerCountry
         val pid = Pid(
             familyName = FamilyName(userInfo.familyName),
             givenName = GivenName(userInfo.givenName),

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/Pid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/Pid.kt
@@ -31,11 +31,7 @@ value class GivenName(val value: String)
  * code as specified in ISO 3166-1.
  */
 @JvmInline
-value class IsoCountry(val value: String) {
-    companion object {
-        val UTOPIA: IsoCountry = IsoCountry("UT")
-    }
-}
+value class IsoCountry(val value: String)
 
 @JvmInline
 value class Street(val value: String)


### PR DESCRIPTION
This PR:

1. Update the Keycloak realm to make `Nationality` a mandatory profile attribute.
2. Updates `GetPidDataFromKeyCloak` to handle gracefully legacy users that no `Nationality` set. Such users will use the value configured for the Country of the Issuer.

Closes #486 