### PR TITLE
Advertise credential_signing_alg_values_supported for MSO MDoc Credential Configurations

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/PidIssuerApplication.kt
@@ -481,6 +481,7 @@ fun beans(clock: Clock) = beans {
                     )
                     val keyAttestationRequirement = keyAttestationRequirement("issuer.pid.mso_mdoc")
                     val issueMsoMdocPid = IssueMsoMdocPid(
+                        issuerSigningKey = ref(),
                         getPidData = ref(),
                         encodePidInCbor = ref(),
                         notificationsEnabled = env.getProperty<Boolean>("issuer.pid.mso_mdoc.notifications.enabled")
@@ -541,6 +542,7 @@ fun beans(clock: Clock) = beans {
                     )
                     val keyAttestationRequirement = keyAttestationRequirement("issuer.mdl")
                     val mdlIssuer = IssueMobileDrivingLicence(
+                        issuerSigningKey = ref(),
                         getMobileDrivingLicenceData = ref(),
                         encodeMobileDrivingLicenceInCbor = ref(),
                         notificationsEnabled = env.getProperty<Boolean>("issuer.mdl.notifications.enabled") ?: true,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/IssuerSigningKey.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/IssuerSigningKey.kt
@@ -24,6 +24,7 @@ import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.util.X509CertChainUtils
 import com.nimbusds.jose.util.X509CertUtils
 import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.pidissuer.domain.CoseAlgorithm
 import eu.europa.ec.eudi.sdjwt.HashAlgorithm
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.SdJwtFactory
@@ -55,6 +56,14 @@ internal val IssuerSigningKey.algorithmId: AlgorithmID
         Curve.P_256 -> AlgorithmID.ECDSA_256
         Curve.P_384 -> AlgorithmID.ECDSA_384
         Curve.P_521 -> AlgorithmID.ECDSA_512
+        else -> error("Unsupported ECKey Curve '$curve'")
+    }
+
+internal val IssuerSigningKey.coseAlgorithm: CoseAlgorithm
+    get() = when (val curve = key.curve) {
+        Curve.P_256 -> CoseAlgorithm(-7)
+        Curve.P_384 -> CoseAlgorithm(-35)
+        Curve.P_521 -> CoseAlgorithm(-36)
         else -> error("Unsupported ECKey Curve '$curve'")
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateJwtProofTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateJwtProofTest.kt
@@ -48,6 +48,7 @@ internal class ValidateJwtProofTest {
     private val verifyKeyAttestation = VerifyKeyAttestation()
     private val validateJwtProof = ValidateJwtProof(issuer, verifyKeyAttestation)
     private val credentialConfiguration = mobileDrivingLicenceV1(
+        CoseAlgorithm(-7),
         checkNotNull(ECDSASigner.SUPPORTED_ALGORITHMS.toNonEmptySetOrNull()),
         KeyAttestationRequirement.NotRequired,
     )
@@ -235,6 +236,7 @@ internal class ValidateJwtProofTest {
             validateJwtProof(
                 UnvalidatedProof.Jwt(signedJwt.serialize()),
                 mobileDrivingLicenceV1(
+                    CoseAlgorithm(-7),
                     nonEmptySetOf(JWSAlgorithm.ES512),
                     KeyAttestationRequirement.NotRequired,
                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ValidateProofTest.kt
@@ -20,6 +20,7 @@ import arrow.core.nonEmptySetOf
 import com.nimbusds.jose.JWSAlgorithm
 import eu.europa.ec.eudi.pidissuer.adapter.out.pid.pidMsoMdocV1
 import eu.europa.ec.eudi.pidissuer.domain.Clock
+import eu.europa.ec.eudi.pidissuer.domain.CoseAlgorithm
 import eu.europa.ec.eudi.pidissuer.domain.CredentialIssuerId
 import eu.europa.ec.eudi.pidissuer.domain.KeyAttestationRequirement
 import eu.europa.ec.eudi.pidissuer.domain.UnvalidatedProof
@@ -51,6 +52,7 @@ class ValidateProofTest {
             validateProofs(
                 nonEmptyListOf(proof),
                 pidMsoMdocV1(
+                    CoseAlgorithm(-7),
                     nonEmptySetOf(JWSAlgorithm.ES256),
                     KeyAttestationRequirement.NotRequired,
                 ),


### PR DESCRIPTION
This PR updates pid-issuer to advertise `credential_signing_alg_values_supported` in MSO MDoc Credential Configurations.