### PR TITLE
feat: match by exact username when fetching data from keycloak

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -160,6 +160,7 @@ class GetPidDataFromKeyCloak(
             .appendPathSegments("admin", "realms", users.value, "users")
             .apply {
                 parameters.append("username", username)
+                parameters.append("exact", "true")
             }
             .build()
 


### PR DESCRIPTION
By default, Keycloak matches usernames by substring, which can lead to unexpected or incorrect user matches. This change sets the `exact` query parameter to ensure only exact username matches.

See: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_users