### PR TITLE
fix: redact issued credential contents from persistence logs

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt
@@ -68,7 +68,7 @@ class InMemoryDeferredCredentialRepository(
                     require(data[transactionId] == null) { "Oops!! $transactionId already exists" }
                 }
                 data[transactionId] = DeferredState(credential, notIssuedBefore)
-                log.info("Stored $transactionId -> $credential ")
+                log.info("Stored deferred credential for transactionId={} notIssuedBefore={}", transactionId, notIssuedBefore)
             }
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryIssuedCredentialRepository.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryIssuedCredentialRepository.kt
@@ -38,7 +38,7 @@ class InMemoryIssuedCredentialRepository(
                     }
                 }
                 data.add(credential)
-                log.info("Stored $credential")
+                log.info("Stored credential of type '{}' with notificationId={}", credential.type, credential.notificationId)
             }
         }
 


### PR DESCRIPTION
## Summary

The in-memory persistence adapters log the full `IssuedCredentials` object and the full `CredentialResponse.Issued` payload at INFO level. These structures contain holder-identifying data (subject identifier, holder public keys) and — for the deferred case — the signed VC/mDoc with the holder's personal claims.

Because application logs are routinely captured by downstream aggregators (ELK, Loki, Datadog, ...) that sit outside the Issuer's trust boundary, a stored credential on stdout means full PID attributes leak to every operator with log-read access.

This PR redacts the log lines to keep only non-sensitive correlation identifiers:
- `InMemoryIssuedCredentialRepository`: credential `type` + `notificationId`
- `InMemoryDeferredCredentialRepository`: `transactionId` + `notIssuedBefore`

These are sufficient to correlate a store with a later load for debugging, without disclosing holder attributes.

Also switched from string interpolation to SLF4J parameterized logging (`"{}"`) as the project's style for info-level logs.

## Changes

- `src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryIssuedCredentialRepository.kt`
- `src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/persistence/InMemoryDeferredCredentialRepository.kt`

2 files changed, 2 insertions(+), 2 deletions(-).

## Test plan

- [ ] Build compiles (`./gradlew build`)
- [ ] Existing tests pass
- [ ] Manual: issue a credential, confirm the log line no longer contains holder/claim data
- [ ] Manual: trigger a deferred issuance store, confirm the log line no longer contains the credential payload