### PR TITLE
Fix encoding of Instant as tdate that contains no fraction of seconds

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/mdl/DefaultEncodeMobileDrivingLicenceInCbor.kt
@@ -22,6 +22,7 @@ import eu.europa.ec.eudi.pidissuer.adapter.out.coseAlgorithm
 import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.GenericRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.mdl.DrivingPrivilege.Restriction.ParameterizedRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.MsoMdocSigner
+import eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc.toTDate
 import eu.europa.ec.eudi.pidissuer.domain.ClaimDefinition
 import eu.europa.ec.eudi.pidissuer.domain.StatusListToken
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError.Unexpected
@@ -29,7 +30,9 @@ import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
 import kotlinx.datetime.toKotlinLocalDate
+import java.time.ZoneOffset
 import kotlin.time.Instant
+import kotlin.time.toKotlinInstant
 
 class DefaultEncodeMobileDrivingLicenceInCbor(issuerSigningKey: IssuerSigningKey) : EncodeMobileDrivingLicenceInCbor {
     override val signingAlgorithm = issuerSigningKey.coseAlgorithm
@@ -70,7 +73,7 @@ private fun MDocBuilder.addItemsToSign(driver: Driver) {
     driver.portrait.capturedAt?.let {
         addItemToSign(
             MsoMdocMdlV1Claims.PortraitCaptureDate,
-            it.toLocalDate().toKotlinLocalDate().toDataElement(),
+            it.toInstant(ZoneOffset.UTC).toKotlinInstant().toTDate(),
         )
     }
     driver.sex?.let { addItemToSign(MsoMdocMdlV1Claims.Sex, it.code.toDataElement()) }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/InstantExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/InstantExtensions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.pidissuer.adapter.out.msomdoc
+
+import id.walt.mdoc.dataelement.TDateElement
+import kotlinx.datetime.toDeprecatedInstant
+import kotlin.time.Instant
+
+fun Instant.dropFractionOfSeconds(): Instant = Instant.fromEpochSeconds(epochSeconds, 0L)
+
+fun Instant.toTDate(): TDateElement = TDateElement(dropFractionOfSeconds().toDeprecatedInstant())

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/msomdoc/MsoMdocSigner.kt
@@ -55,9 +55,9 @@ internal class MsoMdocSigner<in Credential>(
     ): String {
         require(expiresAt >= issuedAt) { "expiresAt must greater or equal to issuedAt" }
         val validityInfo = ValidityInfo(
-            signed = issuedAt.toDeprecatedInstant(),
-            validFrom = issuedAt.toDeprecatedInstant(),
-            validUntil = expiresAt.toDeprecatedInstant(),
+            signed = issuedAt.dropFractionOfSeconds().toDeprecatedInstant(),
+            validFrom = issuedAt.dropFractionOfSeconds().toDeprecatedInstant(),
+            validUntil = expiresAt.dropFractionOfSeconds().toDeprecatedInstant(),
             expectedUpdate = null,
         )
         val deviceKeyInfo = deviceKeyInfo(deviceKey)


### PR DESCRIPTION
This PR updates the encoding of `tdate` DataElement in MSO MDoc Credentials and ensures that fraction of seconds are never included as per ISO 18013-5.

Additionally, this PR fixes the encoding of `portrait_capture_date` in mDL. Per ISO 18013-5 it must be `tdate`. Previously it was incorrectly encoded as `full-date`.

Fixes #538 