### PR TITLE
Fix docker HAProxy configuration

### DIFF
--- a/docker-compose/haproxy/haproxy.conf
+++ b/docker-compose/haproxy/haproxy.conf
@@ -22,6 +22,7 @@ frontend all
     bind 0.0.0.0:443 ssl crt /etc/ssl/certs/localhost.tls.pem
     use_backend keycloak-backend if { path_beg /idp }
     use_backend keycloak-backend if { path_beg /.well-known/oauth-authorization-server/idp/realms/pid-issuer-realm }
+    use_backend pid-issuer-backend if { path_beg /.well-known/openid-credential-issuer/pid-issuer }
     use_backend pid-issuer-metadata if { path /.well-known/jwt-issuer/pid-issuer }
     use_backend pid-issuer-backend if { path_beg /pid-issuer }
 
@@ -39,6 +40,7 @@ backend pid-issuer-backend
     balance roundrobin
     cookie SERVERUSED insert indirect nocache
     option forwarded proto host by by_port for
+    http-request set-path /pid-issuer/.well-known/openid-credential-issuer if { path_beg /.well-known/openid-credential-issuer/pid-issuer }
     server server1 pid-issuer:8080 cookie server1
 
 backend no-match


### PR DESCRIPTION
HAProxy configuration has been updated to handle `./well-known/openid-credential-issuer/pid-issuer` per OpenId4VCI spec.