### PR TITLE
Fix Keycloak `KC_PROXY_HEADERS` in docker-compose

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - --import-realm
       - --features=dpop,passkeys
     environment:
-      - KC_PROXY_HEADERS=xforwarded
+      - KC_PROXY_HEADERS=forwarded
       - KC_HTTP_ENABLED=true
       - KC_HTTP_RELATIVE_PATH=/idp
       - KC_HOSTNAME=https://localhost/idp


### PR DESCRIPTION
`xforwarded` header needs to be replaced by the more generic `forwarded` header.