### PR TITLE
Update R2DBC configuration to use connection pooling and use PostgreSQL

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
   postgres:
     image: postgres:16
     container_name: postgres
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_DB=pid_issuer
       - POSTGRES_USER=pid_issuer
@@ -98,7 +100,7 @@ services:
       - ISSUER_CREDENTIALENDPOINT_BATCHISSUANCE_ENABLED=true
       - ISSUER_CREDENTIALENDPOINT_BATCHISSUANCE_BATCHSIZE=10
       - ISSUER_CNONCE_EXPIRATION=PT5M
-      - SPRING_R2DBC_URL=r2dbc:postgresql://postgres:5432/pid_issuer
+      - SPRING_R2DBC_URL=r2dbc:pool:postgresql://postgres:5432/pid_issuer
       - SPRING_R2DBC_USERNAME=pid_issuer
       - SPRING_R2DBC_PASSWORD=pid_issuer
     networks:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -122,14 +122,17 @@ issuer.trust.service-url=
 
 #
 # Persistence
-# Configure the R2DBC datasource. Use r2dbc:h2 for H2 or r2dbc:postgresql for PostgreSQL.
+# Configure the R2DBC datasource. Use r2dbc:h2 for H2 or r2dbc:pool:postgresql for PostgreSQL.
 # Example for PostgreSQL:
-#   spring.r2dbc.url=r2dbc:postgresql://localhost:5433/pid_issuer
+#   spring.r2dbc.url=r2dbc:pool:postgresql://localhost:5432/pid_issuer
 #   spring.r2dbc.username=pid_issuer
 #   spring.r2dbc.password=pid_issuer
 #   spring.sql.init.mode=always
 # Example for H2 (in-memory):
 #   spring.r2dbc.url=r2dbc:h2:mem:///pid_issuer;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE
 #
-spring.r2dbc.url=r2dbc:h2:mem:///pid_issuer;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE
+spring.r2dbc.url=r2dbc:pool:postgresql://localhost:5432/pid_issuer
+spring.r2dbc.username=pid_issuer
+spring.r2dbc.password=pid_issuer
+spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql


### PR DESCRIPTION
Set PostgreSQL as the default persistence mechanism.
Expose PostgreSQL port in Docker Compose.
Use of connection pooling.