### PR TITLE
Add `basic` and `service_account` client scopes to Keycloak configuration and upgrade to version 26.6.2

### DIFF
--- a/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
+++ b/docker-compose/keycloak/realms/pid-issuer-realm-realm.json
@@ -1456,6 +1456,101 @@
       ]
     },
     {
+      "id": "b0851150-54a9-4679-bcb5-6a414fd79731",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "4859b4af-7e5a-480b-ab67-17dea795bc4c",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "f96a8495-8581-4f7a-9a1f-b31ba4fd6253",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0218a6cd-393d-47d0-8737-585965cda783",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "2dbc9b3c-8932-4565-9ffd-52576d1ff952",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "22297397-d491-4b1a-a1a9-62b5e6954b79",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "edeb6fb8-3de8-41ad-bc63-e2e0162298fd",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
       "id": "44824dfd-c45e-4909-934b-7a3615fe374f",
       "name": "web-origins",
       "description": "OpenID Connect scope for add allowed web origins to the access token",
@@ -1944,7 +2039,9 @@
     }
   ],
   "defaultDefaultClientScopes": [
-    "web-origins"
+    "web-origins",
+    "basic",
+    "service_account"
   ],
   "defaultOptionalClientScopes": [
     "eu.europa.ec.eudi.pid_mso_mdoc",
@@ -2867,7 +2964,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "26.6.2",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []


### PR DESCRIPTION

- Adding missing `basic` and `service_account` client scopes.
- Updating the `keycloakVersion` in realm export to current version.

Closes #593 