### PR TITLE
Remove `Either.catch` and replace `runCatching` with `result`

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/scheduler/CredentialRevocationJob.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/scheduler/CredentialRevocationJob.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.input.scheduler
 
+import arrow.core.raise.context.result
 import eu.europa.ec.eudi.pidissuer.port.input.RevokeCredentialsWithRevokedStatus
 import org.slf4j.LoggerFactory
 
@@ -33,7 +34,7 @@ class CredentialRevocationJob(
     suspend fun run() {
         log.info("Starting credential revocation job")
 
-        runCatching { revokeCredentialsWithRevokedStatus() }
+        result { revokeCredentialsWithRevokedStatus() }
             .onFailure { log.error("Credential revocation job failed", it) }
             .onSuccess { log.info("Credential revocation job completed successfully") }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/ResolveDidUrl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/ResolveDidUrl.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.proof
 
-import arrow.core.Either
 import com.eygraber.uri.Uri
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.*
@@ -44,16 +43,15 @@ import org.bouncycastle.asn1.pkcs.RSAPublicKey as ANS1RSAPublicKey
  *
  * methods are supported.
  */
-fun resolveDidUrl(uri: Uri): Either<Throwable, JWK> =
-    Either.catch {
-        val (scheme, methodName, _) = uri.toString().split(":")
-        require("did" == scheme) { "Unexpected scheme $scheme" }
-        when (methodName) {
-            "key" -> resolveDidKey(uri)
-            "jwk" -> resolveDidJwk(uri)
-            else -> error("Unsupported DID method '$methodName'")
-        }
+fun resolveDidUrl(uri: Uri): JWK {
+    val (scheme, methodName, _) = uri.toString().split(":")
+    require("did" == scheme) { "Unexpected scheme $scheme" }
+    return when (methodName) {
+        "key" -> resolveDidKey(uri)
+        "jwk" -> resolveDidJwk(uri)
+        else -> error("Unsupported DID method '$methodName'")
     }
+}
 
 private val supportedDidKeyTypes =
     setOf(

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/VerifyKeyAttestation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/VerifyKeyAttestation.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.proof
 
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
-import arrow.core.getOrElse
 import arrow.core.raise.Raise
 import arrow.core.raise.context.ensure
 import arrow.core.raise.context.raise

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/VerifyKeyAttestation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/proof/VerifyKeyAttestation.kt
@@ -121,7 +121,7 @@ class VerifyKeyAttestation(
         return when {
             kid != null && x5c.isNullOrEmpty() -> {
                 val didUrl = Uri.parse(kid)
-                val jwk = resolveDidUrl(didUrl).getOrElse { throw it }
+                val jwk = resolveDidUrl(didUrl)
                 WalletProviderSigningKey.DIDUrl(jwk, didUrl)
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/x509/Utils.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/x509/Utils.kt
@@ -15,11 +15,12 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.x509
 
+import arrow.core.raise.context.result
 import java.security.cert.X509Certificate
 
 fun X509Certificate.isSelfSigned(): Boolean =
     subjectX500Principal == issuerX500Principal &&
-        runCatching {
+        result {
             verify(publicKey)
             true
         }.getOrElse { false }

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptCredentialResponseWithNimbusTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/EncryptCredentialResponseWithNimbusTest.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.jose
 
-import arrow.core.Either
 import arrow.core.getOrElse
 import arrow.core.raise.either
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -127,7 +126,7 @@ internal class EncryptCredentialResponseWithNimbusTest {
                     )
             }
 
-        val claims = Either.catch { processor.process(encrypted.jwt, null) }.getOrElse { fail(it.message, it) }
+        val claims = processor.process(encrypted.jwt, null)
         val credential =
             claims
                 .getListClaim("credentials")
@@ -135,12 +134,9 @@ internal class EncryptCredentialResponseWithNimbusTest {
                     it.map { credential ->
                         when (credential) {
                             is Map<*, *> -> {
-                                Either
-                                    .catch {
-                                        Json.decodeFromString<IssueCredentialResponse.PlainTO.CredentialTO>(
-                                            jacksonObjectMapper.writeValueAsString(credential),
-                                        )
-                                    }.getOrElse { error -> fail(error.message, error) }
+                                Json.decodeFromString<IssueCredentialResponse.PlainTO.CredentialTO>(
+                                    jacksonObjectMapper.writeValueAsString(credential),
+                                )
                             }
 
                             else -> {

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ResolveDidUrlTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/jose/ResolveDidUrlTest.kt
@@ -15,11 +15,9 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.jose
 
-import arrow.core.getOrElse
 import com.eygraber.uri.Uri
 import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.pidissuer.adapter.out.proof.resolveDidUrl
-import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,7 +28,7 @@ internal class ResolveDidUrlTest {
     @Test
     fun `verify did key method resolution success`() {
         testData.forEach { (did, jwk) ->
-            val resolved = assertDoesNotThrow { resolveDidUrl(Uri.parse(did)).getOrElse { throw it } }
+            val resolved = resolveDidUrl(Uri.parse(did))
             assertEquals(jwk, resolved)
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/port/input/RevokeCredentialsWithRevokedStatusTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/port/input/RevokeCredentialsWithRevokedStatusTest.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.pidissuer.port.input
 
 import arrow.core.raise.context.raise
+import arrow.core.raise.context.result
 import arrow.core.right
 import com.eygraber.uri.Uri
 import eu.europa.ec.eudi.pidissuer.domain.Format
@@ -253,7 +254,8 @@ internal class RevokeCredentialsWithRevokedStatusTest {
                     deleteIssuedCredential = { },
                 )
 
-            assertEquals("DB error", runCatching { useCase() }.exceptionOrNull()?.message)
+            val error = result { useCase() }.exceptionOrNull()?.message
+            assertEquals("DB error", error)
         }
 
     @Test


### PR DESCRIPTION
This PR removes the last remnants of `Either.catch`/`Either<Throwable, T>` and replaces `runCatching` usages with Arrow's `result`.