### PR TITLE
Fix creation of well-known links

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/IssuerUi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/IssuerUi.kt
@@ -105,6 +105,7 @@ class IssuerUi(
             HttpsUrl.unsafe(
                 value
                     .buildUpon()
+                    .path(null)
                     .appendPath(".well-known")
                     .appendPath(path)
                     .apply {


### PR DESCRIPTION
Ensure `.well-known/{path}` is properly encoded between host and the existing path.