### PR TITLE
Add validation for Credential Request Encryption key use

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerEnvironmentExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerEnvironmentExtensions.kt
@@ -175,9 +175,6 @@ internal fun Environment.credentialRequestEncryption(issuerKeystore: () -> KeySt
                     issuerKeystore().loadJwk(this, "issuer.credentialRequestEncryption.jwks")
             ) {
                 is ECKey -> {
-                    require(KeyUse.ENCRYPTION == loadedJwk.keyUse) {
-                        "Credential Request Encryption key must have key use 'enc'"
-                    }
                     require(keyAlgorithm in loadedJwk.supportedJWEAlgorithms) {
                         "${keyAlgorithm.name} cannot be used with an ECKey"
                     }
@@ -185,9 +182,6 @@ internal fun Environment.credentialRequestEncryption(issuerKeystore: () -> KeySt
                 }
 
                 is RSAKey -> {
-                    require(KeyUse.ENCRYPTION == loadedJwk.keyUse) {
-                        "Credential Request Encryption key must have key use 'enc'"
-                    }
                     require(keyAlgorithm in loadedJwk.supportedJWEAlgorithms) {
                         "${keyAlgorithm.name} cannot be used with an RSAKey"
                     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerEnvironmentExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerEnvironmentExtensions.kt
@@ -175,6 +175,9 @@ internal fun Environment.credentialRequestEncryption(issuerKeystore: () -> KeySt
                     issuerKeystore().loadJwk(this, "issuer.credentialRequestEncryption.jwks")
             ) {
                 is ECKey -> {
+                    require(KeyUse.ENCRYPTION == loadedJwk.keyUse) {
+                        "Credential Request Encryption key must have key use 'enc'"
+                    }
                     require(keyAlgorithm in loadedJwk.supportedJWEAlgorithms) {
                         "${keyAlgorithm.name} cannot be used with an ECKey"
                     }
@@ -182,6 +185,9 @@ internal fun Environment.credentialRequestEncryption(issuerKeystore: () -> KeySt
                 }
 
                 is RSAKey -> {
+                    require(KeyUse.ENCRYPTION == loadedJwk.keyUse) {
+                        "Credential Request Encryption key must have key use 'enc'"
+                    }
                     require(keyAlgorithm in loadedJwk.supportedJWEAlgorithms) {
                         "${keyAlgorithm.name} cannot be used with an RSAKey"
                     }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -23,6 +23,7 @@ import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import eu.europa.ec.eudi.pidissuer.domain.OpenId4VciSpec.ZIP_ALGORITHMS
 import eu.europa.ec.eudi.pidissuer.port.out.attestation.AttestationIssuer
@@ -51,6 +52,7 @@ data class CredentialRequestEncryptionSupportedParameters(
 ) {
     init {
         require(encryptionKeys.keys.isNotEmpty()) { "encryptionKeys must contain at least one key" }
+        require(encryptionKeys.keys.all { KeyUse.ENCRYPTION == it.keyUse }) { "encryptionKeys must have key use 'enc'" }
         require(encryptionKeys.keys.all { it.isPrivate }) { "encryptionKeys must contain only private keys" }
         require(encryptionKeys.keys.all { !it.keyID.isNullOrBlank() }) { "encryptionKeys must contain keys with a kid value" }
         require(encryptionKeys.keys.all { it.algorithm != null }) { "encryptionKeys must contain keys with an alg value" }

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetDeferredCredentialTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/port/input/GetDeferredCredentialTest.kt
@@ -24,6 +24,7 @@ import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.EncryptedJWT
 import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.pid.pidMsoMdocV1
@@ -199,6 +200,7 @@ class GetDeferredCredentialTest {
             val encryptionKey =
                 ECKeyGenerator(Curve.P_256)
                     .keyID("test-kid")
+                    .keyUse(KeyUse.ENCRYPTION)
                     .algorithm(JWEAlgorithm.ECDH_ES)
                     .generate()
             val encryptionParams =


### PR DESCRIPTION
Now loading a credential request encryption key requires `use: enc`.