### PR TITLE
Use DSS EAA MDoc to issue MSO MDoc Credentials and sign using CB-AdES

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(platform(libs.kotlinx.coroutines.bom))
     implementation(platform(libs.kotlinx.serialization.bom))
     implementation(platform(libs.arrow.stack))
+    implementation(platform(libs.dss.bom))
     implementation(platform(SpringBootPlugin.BOM_COORDINATES))
 
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server") {
@@ -95,6 +96,9 @@ dependencies {
     runtimeOnly("org.postgresql:r2dbc-postgresql") {
         because("R2DBC driver for PostgreSQL")
     }
+    implementation(libs.dss.utils.apache.commons)
+    implementation(libs.dss.token)
+    implementation(libs.dss.cb.ades)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://maven.waltid.dev/releases")
-        mavenContent {
-        }
-    }
 }
 
 dependencies {
@@ -74,15 +69,7 @@ dependencies {
     implementation(libs.nimbus.oauth2) {
         because("To support DPoP")
     }
-    implementation(libs.waltid.mdoc.credentials) {
-        because("To sign CBOR credentials")
-    }
-    implementation(libs.kotlinx.datetime) {
-        because("required by walt.id")
-    }
-    implementation(libs.cose.java) {
-        because("required by walt.id")
-    }
+    implementation(libs.kotlinx.datetime)
     implementation(libs.uri.kmp) {
         because("To generate Credentials Offer URIs using custom URIs")
     }
@@ -99,6 +86,7 @@ dependencies {
     implementation(libs.dss.utils.apache.commons)
     implementation(libs.dss.token)
     implementation(libs.dss.cb.ades)
+    implementation(libs.dss.eaa.mdoc)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,13 +17,11 @@ dependencyCheck = "12.2.2"
 bootstrap = "5.3.8"
 multiformat = "1.1.0"
 resultMonad = "1.4.0"
-waltid = "0.11.0"
 uri-kmp = "0.0.21"
 zxing = "3.5.4"
 tink = "1.22.0"
 kover = "0.9.8"
-cose-java = "1.1.0"
-kotlinx-datetime = "0.8.0-0.6.x-compat"
+kotlinx-datetime = "0.8.0"
 dss = "6.5.RC1"
 
 [libraries]
@@ -45,16 +43,15 @@ bootstrap = { module = "org.webjars:bootstrap", version.ref = "bootstrap" }
 tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 multiformat = { module = "org.erwinkok.multiformat:multiformat", version.ref = "multiformat" }
 result-monad = { module = "org.erwinkok.result:result-monad", version.ref = "resultMonad" }
-waltid-mdoc-credentials = { module = "id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm", version.ref = "waltid" }
 uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 zxing = { module = "com.google.zxing:javase", version.ref = "zxing" }
-cose-java = { module = "com.augustcellars.cose:cose-java", version.ref = "cose-java" }
 statium = { module = "eu.europa.ec.eudi:eudi-lib-kmp-statium-jvm", version.ref = "statium" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 dss-bom = { module = "eu.europa.ec.joinup.sd-dss:dss-bom", version.ref = "dss" }
 dss-utils-apache-commons = { module = "eu.europa.ec.joinup.sd-dss:dss-utils-apache-commons" }
 dss-token = { module = "eu.europa.ec.joinup.sd-dss:dss-token" }
 dss-cb-ades = { module = "eu.europa.ec.joinup.sd-dss:dss-cb-ades" }
+dss-eaa-mdoc = { module = "eu.europa.ec.joinup.sd-dss:dss-eaa-mdoc" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ tink = "1.22.0"
 kover = "0.9.8"
 cose-java = "1.1.0"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
+dss = "6.5.RC1"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -32,7 +33,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-bom = { module = "org.jetbrains.kotlinx:kotlinx-serialization-bom", version.ref = "kotlinxSerialization" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 arrow-stack = { module = "io.arrow-kt:arrow-stack", version.ref = "arrow" }
-arrow-core  = { module = "io.arrow-kt:arrow-core" }
+arrow-core = { module = "io.arrow-kt:arrow-core" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines" }
 arrow-core-serialization = { module = "io.arrow-kt:arrow-core-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json" }
@@ -50,6 +51,10 @@ zxing = { module = "com.google.zxing:javase", version.ref = "zxing" }
 cose-java = { module = "com.augustcellars.cose:cose-java", version.ref = "cose-java" }
 statium = { module = "eu.europa.ec.eudi:eudi-lib-kmp-statium-jvm", version.ref = "statium" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
+dss-bom = { module = "eu.europa.ec.joinup.sd-dss:dss-bom", version.ref = "dss" }
+dss-utils-apache-commons = { module = "eu.europa.ec.joinup.sd-dss:dss-utils-apache-commons" }
+dss-token = { module = "eu.europa.ec.joinup.sd-dss:dss-token" }
+dss-cb-ades = { module = "eu.europa.ec.joinup.sd-dss:dss-cb-ades" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/IssuerSigningKey.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/IssuerSigningKey.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out
 
-import COSE.AlgorithmID
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDSASigner
@@ -27,8 +26,6 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.pidissuer.adapter.out.x509.dropRootCA
 import eu.europa.ec.eudi.pidissuer.domain.CoseAlgorithm
 import eu.europa.ec.eudi.sdjwt.*
-import id.walt.mdoc.COSECryptoProviderKeyInfo
-import id.walt.mdoc.SimpleCOSECryptoProvider
 import java.security.cert.X509Certificate
 
 @JvmInline
@@ -51,15 +48,6 @@ internal val IssuerSigningKey.signingAlgorithm: JWSAlgorithm
             else -> error("Unsupported ECKey Curve '$curve'")
         }
 
-internal val IssuerSigningKey.algorithmId: AlgorithmID
-    get() =
-        when (val curve = key.curve) {
-            Curve.P_256 -> AlgorithmID.ECDSA_256
-            Curve.P_384 -> AlgorithmID.ECDSA_384
-            Curve.P_521 -> AlgorithmID.ECDSA_512
-            else -> error("Unsupported ECKey Curve '$curve'")
-        }
-
 internal val IssuerSigningKey.coseAlgorithm: CoseAlgorithm
     get() =
         when (val curve = key.curve) {
@@ -68,24 +56,6 @@ internal val IssuerSigningKey.coseAlgorithm: CoseAlgorithm
             Curve.P_521 -> CoseAlgorithm(-36)
             else -> error("Unsupported ECKey Curve '$curve'")
         }
-
-internal fun IssuerSigningKey.cryptoProvider(includeRootCA: Boolean): SimpleCOSECryptoProvider =
-    SimpleCOSECryptoProvider(
-        listOf(
-            COSECryptoProviderKeyInfo(
-                keyID = key.keyID,
-                algorithmID = algorithmId,
-                publicKey = key.toECPublicKey(),
-                privateKey = key.toECPrivateKey(),
-                x5Chain =
-                    if (includeRootCA)
-                        key.parsedX509CertChain
-                    else
-                        key.parsedX509CertChain.dropRootCA(),
-                trustedRootCAs = emptyList(),
-            ),
-        ),
-    )
 
 internal val IssuerSigningKey.certificate: X509Certificate
     get() = X509CertUtils.parse(key.x509CertChain.first().decode())

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/IssueMdoc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/IssueMdoc.kt
@@ -21,7 +21,7 @@ import arrow.fx.coroutines.parMap
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.AttestationAttributes
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.EncodeAttestationAttributes
-import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.encodeAttestationAttributesInMdoc
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.EncodeAttestationAttributesInMdoc
 import eu.europa.ec.eudi.pidissuer.domain.*
 import eu.europa.ec.eudi.pidissuer.port.input.AuthorizationContext
 import eu.europa.ec.eudi.pidissuer.port.input.IssueCredentialError
@@ -33,7 +33,7 @@ import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredential
 import eu.europa.ec.eudi.pidissuer.port.out.proof.ValidateProof
 import eu.europa.ec.eudi.pidissuer.port.out.status.AllocateStatus
-import id.walt.mdoc.doc.MDocBuilder
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAClaimParameters
 import kotlinx.coroutines.Dispatchers
 import org.slf4j.LoggerFactory
 import kotlin.time.Clock
@@ -111,7 +111,7 @@ class IssueMdoc<Attr>(
             getAttestationAttributes: GetAttestationAttributes<Data>,
             allocateStatus: AllocateStatus?,
             issuerSigningKey: IssuerSigningKey,
-            usage: MDocBuilder.(Data) -> Unit,
+            usage: MdocEAAClaimParameters.(Data) -> Unit,
         ): IssueMdoc<Data> =
             IssueMdoc(
                 configuration,
@@ -121,7 +121,7 @@ class IssueMdoc<Attr>(
                 storeIssuedCredential,
                 getAttestationAttributes,
                 allocateStatus,
-                encodeAttestationAttributesInMdoc(configuration.docType, issuerSigningKey, usage = usage),
+                EncodeAttestationAttributesInMdoc(issuerSigningKey, configuration.docType, usage),
             )
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/mdl/IssueMobileDrivingLicence.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/mdl/IssueMobileDrivingLicence.kt
@@ -22,17 +22,18 @@ import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.IssueMdoc
 import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.mdl.DrivingPrivilege.Restriction.GenericRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.mdl.DrivingPrivilege.Restriction.ParameterizedRestriction
 import eu.europa.ec.eudi.pidissuer.adapter.out.coseAlgorithm
-import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.encodeAttestationAttributesInMdoc
-import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.toTDate
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.EncodeAttestationAttributesInMdoc
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.addItemToSign
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.toFullDate
 import eu.europa.ec.eudi.pidissuer.domain.*
 import eu.europa.ec.eudi.pidissuer.port.out.attestation.GetAttestationAttributes
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredential
 import eu.europa.ec.eudi.pidissuer.port.out.proof.ValidateProof
 import eu.europa.ec.eudi.pidissuer.port.out.status.AllocateStatus
-import id.walt.mdoc.dataelement.DataElement
-import id.walt.mdoc.dataelement.toDataElement
-import id.walt.mdoc.doc.MDocBuilder
+import eu.europa.esig.dss.cbades.cbor.CBORObject
+import eu.europa.esig.dss.cbades.cbor.CBORObjectFactory
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAClaimParameters
 import kotlinx.datetime.toKotlinLocalDate
 import java.time.ZoneOffset
 import kotlin.time.Clock
@@ -62,9 +63,7 @@ fun IssueMobileDrivingLicence(
         storeIssuedCredential,
         getAttestationAttributes,
         allocateStatus,
-        encodeAttestationAttributesInMdoc(configuration.docType, issuerSigningKey) { licence ->
-            addItemsToSign(licence)
-        },
+        EncodeAttestationAttributesInMdoc(issuerSigningKey, configuration.docType) { addItemsToSign(it) },
     )
 }
 
@@ -89,149 +88,121 @@ internal fun mdlV1Cfg(
     )
 }
 
-private fun MDocBuilder.addItemsToSign(licence: MobileDrivingLicence) {
+private fun MdocEAAClaimParameters.addItemsToSign(licence: MobileDrivingLicence) {
     addItemsToSign(licence.driver)
     addItemsToSign(licence.issueAndExpiry)
     addItemsToSign(licence.issuer)
-    addItemToSign(MsoMdocMdlV1Claims.DocumentNumber, licence.documentNumber.value.toDataElement())
-    addItemToSign(MsoMdocMdlV1Claims.DrivingPrivileges, licence.privileges.map { it.toDE() }.toDataElement())
-    licence.administrativeNumber?.let {
-        addItemToSign(
-            MsoMdocMdlV1Claims.AdministrativeNumber,
-            it.value.toDataElement(),
-        )
-    }
+    addItemToSign(MsoMdocMdlV1Claims.DocumentNumber, licence.documentNumber.value)
+    addItemToSign(MsoMdocMdlV1Claims.DrivingPrivileges, licence.privileges.map { it.toCBORObject() })
+    licence.administrativeNumber?.let { addItemToSign(MsoMdocMdlV1Claims.AdministrativeNumber, it.value) }
 }
 
-private fun MDocBuilder.addItemsToSign(driver: Driver) {
-    addItemToSign(
-        MsoMdocMdlV1Claims.FamilyName,
-        driver.familyName.latin.value
-            .toDataElement(),
-    )
-    addItemToSign(
-        MsoMdocMdlV1Claims.GivenName,
-        driver.givenName.latin.value
-            .toDataElement(),
-    )
-    addItemToSign(MsoMdocMdlV1Claims.BirthDate, driver.birthDate.toKotlinLocalDate().toDataElement())
-    addItemToSign(
-        MsoMdocMdlV1Claims.Portrait,
-        driver.portrait.image.content
-            .toDataElement(),
-    )
+private fun MdocEAAClaimParameters.addItemsToSign(driver: Driver) {
+    addItemToSign(MsoMdocMdlV1Claims.FamilyName, driver.familyName.latin.value)
+    addItemToSign(MsoMdocMdlV1Claims.GivenName, driver.givenName.latin.value)
+    addItemToSign(MsoMdocMdlV1Claims.BirthDate, driver.birthDate.toKotlinLocalDate())
+    addItemToSign(MsoMdocMdlV1Claims.Portrait, driver.portrait.image.content)
     driver.portrait.capturedAt?.let {
         addItemToSign(
             MsoMdocMdlV1Claims.PortraitCaptureDate,
-            it.toInstant(ZoneOffset.UTC).toKotlinInstant().toTDate(),
+            it.toInstant(ZoneOffset.UTC).toKotlinInstant(),
         )
     }
-    driver.sex?.let { addItemToSign(MsoMdocMdlV1Claims.Sex, it.code.toDataElement()) }
-    driver.height?.let { addItemToSign(MsoMdocMdlV1Claims.Height, it.value.toDataElement()) }
-    driver.weight?.let { addItemToSign(MsoMdocMdlV1Claims.Weight, it.value.toDataElement()) }
-    driver.eyeColour?.let { addItemToSign(MsoMdocMdlV1Claims.EyeColour, it.code.toDataElement()) }
-    driver.hairColour?.let { addItemToSign(MsoMdocMdlV1Claims.HairColour, it.code.toDataElement()) }
-    driver.birthPlace?.let { addItemToSign(MsoMdocMdlV1Claims.BirthPlace, it.value.toDataElement()) }
+    driver.sex?.let { addItemToSign(MsoMdocMdlV1Claims.Sex, it.code) }
+    driver.height?.let { addItemToSign(MsoMdocMdlV1Claims.Height, it.value) }
+    driver.weight?.let { addItemToSign(MsoMdocMdlV1Claims.Weight, it.value) }
+    driver.eyeColour?.let { addItemToSign(MsoMdocMdlV1Claims.EyeColour, it.code) }
+    driver.hairColour?.let { addItemToSign(MsoMdocMdlV1Claims.HairColour, it.code) }
+    driver.birthPlace?.let { addItemToSign(MsoMdocMdlV1Claims.BirthPlace, it.value) }
     driver.residence?.let { residence ->
-        residence.address?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentAddress, it.value.toDataElement()) }
-        residence.city?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentCity, it.value.toDataElement()) }
-        residence.state?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentState, it.value.toDataElement()) }
-        residence.postalCode?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentPostalCode, it.value.toDataElement()) }
-        addItemToSign(MsoMdocMdlV1Claims.ResidentCountry, residence.country.code.toDataElement())
+        residence.address?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentAddress, it.value) }
+        residence.city?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentCity, it.value) }
+        residence.state?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentState, it.value) }
+        residence.postalCode?.let { addItemToSign(MsoMdocMdlV1Claims.ResidentPostalCode, it.value) }
+        addItemToSign(MsoMdocMdlV1Claims.ResidentCountry, residence.country.code)
     }
     driver.age?.let { age ->
-        addItemToSign(MsoMdocMdlV1Claims.AgeInYears, age.value.value.toDataElement())
-        age.birthYear?.let { addItemToSign(MsoMdocMdlV1Claims.AgeBirthYear, it.value.toDataElement()) }
-        addItemToSign(MsoMdocMdlV1Claims.AgeOver18, age.over18.toDataElement())
-        addItemToSign(MsoMdocMdlV1Claims.AgeOver21, age.over21.toDataElement())
+        addItemToSign(MsoMdocMdlV1Claims.AgeInYears, age.value.value)
+        age.birthYear?.let { addItemToSign(MsoMdocMdlV1Claims.AgeBirthYear, it.value) }
+        addItemToSign(MsoMdocMdlV1Claims.AgeOver18, age.over18)
+        addItemToSign(MsoMdocMdlV1Claims.AgeOver21, age.over21)
     }
-    driver.nationality?.let { addItemToSign(MsoMdocMdlV1Claims.Nationality, it.code.toDataElement()) }
-    driver.familyName.utf8?.let { addItemToSign(MsoMdocMdlV1Claims.FamilyNameNationalCharacter, it.toDataElement()) }
-    driver.givenName.utf8?.let { addItemToSign(MsoMdocMdlV1Claims.GivenNameNationalCharacter, it.toDataElement()) }
-    driver.signature?.let { addItemToSign(MsoMdocMdlV1Claims.SignatureUsualMark, it.content.toDataElement()) }
+    driver.nationality?.let { addItemToSign(MsoMdocMdlV1Claims.Nationality, it.code) }
+    driver.familyName.utf8?.let { addItemToSign(MsoMdocMdlV1Claims.FamilyNameNationalCharacter, it) }
+    driver.givenName.utf8?.let { addItemToSign(MsoMdocMdlV1Claims.GivenNameNationalCharacter, it) }
+    driver.signature?.let { addItemToSign(MsoMdocMdlV1Claims.SignatureUsualMark, it.content) }
 }
 
-private fun MDocBuilder.addItemsToSign(issueAndExpiry: IssueAndExpiry) {
-    addItemToSign(MsoMdocMdlV1Claims.IssueDate, issueAndExpiry.issuedAt.toKotlinLocalDate().toDataElement())
-    addItemToSign(MsoMdocMdlV1Claims.ExpiryDate, issueAndExpiry.expiresAt.toKotlinLocalDate().toDataElement())
+private fun MdocEAAClaimParameters.addItemsToSign(issueAndExpiry: IssueAndExpiry) {
+    addItemToSign(MsoMdocMdlV1Claims.IssueDate, issueAndExpiry.issuedAt.toKotlinLocalDate())
+    addItemToSign(MsoMdocMdlV1Claims.ExpiryDate, issueAndExpiry.expiresAt.toKotlinLocalDate())
 }
 
-private fun MDocBuilder.addItemsToSign(issuer: Issuer) {
-    addItemToSign(
-        MsoMdocMdlV1Claims.IssuingCountry,
-        issuer.country.countryCode.code
-            .toDataElement(),
-    )
-    addItemToSign(MsoMdocMdlV1Claims.IssuingAuthority, issuer.authority.value.toDataElement())
-    addItemToSign(
-        MsoMdocMdlV1Claims.IssuingCountryDistinguishingSign,
-        issuer.country.distinguishingSign.code
-            .toDataElement(),
-    )
-    issuer.jurisdiction?.let { addItemToSign(MsoMdocMdlV1Claims.IssuingJurisdiction, it.value.toDataElement()) }
+private fun MdocEAAClaimParameters.addItemsToSign(issuer: Issuer) {
+    addItemToSign(MsoMdocMdlV1Claims.IssuingCountry, issuer.country.countryCode.code)
+    addItemToSign(MsoMdocMdlV1Claims.IssuingAuthority, issuer.authority.value)
+    addItemToSign(MsoMdocMdlV1Claims.IssuingCountryDistinguishingSign, issuer.country.distinguishingSign.code)
+    issuer.jurisdiction?.let { addItemToSign(MsoMdocMdlV1Claims.IssuingJurisdiction, it.value) }
 }
 
-private fun MDocBuilder.addItemToSign(
-    claim: ClaimDefinition,
-    value: DataElement,
-) {
-    addItemToSign(MsoMdocMdlV1Claims.nameSpace, claim.name, value)
-}
-
-private fun DrivingPrivilege.toDE() =
-    buildMap {
-        put("vehicle_category_code", vehicleCategory.code.toDataElement())
-        issueAndExpiry?.let { issueAndExpiry ->
-            put("issue_date", issueAndExpiry.issuedAt.toKotlinLocalDate().toDataElement())
-            put("expiry_date", issueAndExpiry.expiresAt.toKotlinLocalDate().toDataElement())
-        }
-        restrictions?.let { restrictions ->
-            put("codes", restrictions.map { it.toDE() }.toDataElement())
-        }
-    }.toDataElement()
-
-private fun DrivingPrivilege.Restriction.toDE() =
-    buildMap {
-        val (code, sign, value) =
-            when (this@toDE) {
-                is GenericRestriction -> {
-                    Triple(code, null, null)
-                }
-
-                is ParameterizedRestriction.VehiclePower -> {
-                    Triple(
-                        code,
-                        value.code,
-                        value.value.value,
-                    )
-                }
-
-                is ParameterizedRestriction.VehicleAuthorizedMass -> {
-                    Triple(
-                        code,
-                        value.code,
-                        value.value.value,
-                    )
-                }
-
-                is ParameterizedRestriction.VehicleCylinderCapacity -> {
-                    Triple(
-                        code,
-                        value.code,
-                        value.value.value,
-                    )
-                }
-
-                is ParameterizedRestriction.VehicleAuthorizedPassengerSeats -> {
-                    Triple(
-                        code,
-                        value.code,
-                        value.value.value,
-                    )
-                }
+private fun DrivingPrivilege.toCBORObject(): CBORObject =
+    CBORObjectFactory.toCBORObject(
+        buildMap {
+            put("vehicle_category_code", vehicleCategory.code)
+            issueAndExpiry?.let { issueAndExpiry ->
+                put("issue_date", issueAndExpiry.issuedAt.toKotlinLocalDate().toFullDate())
+                put("expiry_date", issueAndExpiry.expiresAt.toKotlinLocalDate().toFullDate())
             }
+            restrictions?.let { restrictions ->
+                put("codes", restrictions.map { it.toCBORObject() })
+            }
+        },
+    )
 
-        put("code", code.toDataElement())
-        sign?.let { put("sign", it.toDataElement()) }
-        value?.let { put("value", it.toString().toDataElement()) }
-    }.toDataElement()
+private fun DrivingPrivilege.Restriction.toCBORObject(): CBORObject =
+    CBORObjectFactory.toCBORObject(
+        buildMap {
+            val (code, sign, value) =
+                when (this@toCBORObject) {
+                    is GenericRestriction -> {
+                        Triple(code, null, null)
+                    }
+
+                    is ParameterizedRestriction.VehiclePower -> {
+                        Triple(
+                            code,
+                            value.code,
+                            value.value.value,
+                        )
+                    }
+
+                    is ParameterizedRestriction.VehicleAuthorizedMass -> {
+                        Triple(
+                            code,
+                            value.code,
+                            value.value.value,
+                        )
+                    }
+
+                    is ParameterizedRestriction.VehicleCylinderCapacity -> {
+                        Triple(
+                            code,
+                            value.code,
+                            value.value.value,
+                        )
+                    }
+
+                    is ParameterizedRestriction.VehicleAuthorizedPassengerSeats -> {
+                        Triple(
+                            code,
+                            value.code,
+                            value.value.value,
+                        )
+                    }
+                }
+
+            put("code", code)
+            sign?.let { put("sign", it) }
+            value?.let { put("value", it.toString()) }
+        },
+    )

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/pid/IssueMsoMdocPid.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/pid/IssueMsoMdocPid.kt
@@ -19,17 +19,21 @@ import arrow.core.nonEmptySetOf
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.IssueMdoc
 import eu.europa.ec.eudi.pidissuer.adapter.out.coseAlgorithm
-import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.encodeAttestationAttributesInMdoc
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.EncodeAttestationAttributesInMdoc
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.addItemToSign
+import eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc.toFullDate
 import eu.europa.ec.eudi.pidissuer.domain.*
 import eu.europa.ec.eudi.pidissuer.port.out.attestation.GetAttestationAttributes
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.GenerateNotificationId
 import eu.europa.ec.eudi.pidissuer.port.out.persistence.StoreIssuedCredential
 import eu.europa.ec.eudi.pidissuer.port.out.proof.ValidateProof
 import eu.europa.ec.eudi.pidissuer.port.out.status.AllocateStatus
-import id.walt.mdoc.dataelement.DataElement
-import id.walt.mdoc.dataelement.MapKey
-import id.walt.mdoc.dataelement.toDataElement
-import id.walt.mdoc.doc.MDocBuilder
+import eu.europa.esig.dss.cbades.cbor.CBORObjectFactory
+import eu.europa.esig.dss.cbades.cbor.CBORUtils
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAClaimParameters
+import eu.europa.esig.dss.eaa.mdoc.creation.claim.MdocEAAClaim
+import eu.europa.esig.dss.spi.DSSUtils
+import kotlinx.datetime.LocalDate
 import java.util.Locale.ENGLISH
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -106,85 +110,77 @@ fun IssueMsoMdocPid(
         storeIssuedCredential,
         getAttestationAttributes,
         allocateStatus,
-        encodeAttestationAttributesInMdoc(configuration.docType, issuerSigningKey, { pidAttributes(it) }),
+        EncodeAttestationAttributesInMdoc(issuerSigningKey, configuration.docType) { pidAttributes(it) },
     )
 }
 
-private fun MDocBuilder.pidAttributes(pidAttributes: PidAttributes) {
+private fun MdocEAAClaimParameters.pidAttributes(pidAttributes: PidAttributes) {
     addItemsToSign(pidAttributes.pid)
     addItemsToSign(pidAttributes.metaData)
 }
 
-private fun MDocBuilder.addItemsToSign(pid: Pid) {
-    addItemToSign(MsoMdocPidClaims.FamilyName, pid.familyName.value.toDataElement())
-    addItemToSign(MsoMdocPidClaims.GivenName, pid.givenName.value.toDataElement())
-    addItemToSign(MsoMdocPidClaims.BirthDate, pid.birthDate.toDataElement())
+private fun MdocEAAClaimParameters.addItemsToSign(pid: Pid) {
+    addItemToSign(MsoMdocPidClaims.FamilyName, pid.familyName.value)
+    addItemToSign(MsoMdocPidClaims.GivenName, pid.givenName.value)
+    addItemToSign(MsoMdocPidClaims.BirthDate, pid.birthDate)
 
     val placeOfBirth =
         with(pid.placeOfBirth) {
-            buildMap {
-                country?.let { put(MapKey("country"), it.value.toDataElement()) }
-                region?.let { put(MapKey("region"), it.value.toDataElement()) }
-                locality?.let { put(MapKey("locality"), it.value.toDataElement()) }
-            }.toDataElement()
+            CBORObjectFactory.toCBORObject(
+                buildMap {
+                    country?.let { put("country", it.value) }
+                    region?.let { put("region", it.value) }
+                    locality?.let { put("locality", it.value) }
+                },
+            )
         }
     addItemToSign(MsoMdocPidClaims.PlaceOfBirth, placeOfBirth)
 
-    addItemToSign(MsoMdocPidClaims.Nationality, pid.nationalities.map { it.value.toDataElement() }.toDataElement())
-    pid.residentAddress?.let { addItemToSign(MsoMdocPidClaims.ResidenceAddress, it.toDataElement()) }
-    pid.residentCountry?.let { addItemToSign(MsoMdocPidClaims.ResidenceCountry, it.value.toDataElement()) }
-    pid.residentState?.let { addItemToSign(MsoMdocPidClaims.ResidenceState, it.value.toDataElement()) }
-    pid.residentCity?.let { addItemToSign(MsoMdocPidClaims.ResidenceCity, it.value.toDataElement()) }
-    pid.residentPostalCode?.let { addItemToSign(MsoMdocPidClaims.ResidencePostalCode, it.value.toDataElement()) }
-    pid.residentStreet?.let { addItemToSign(MsoMdocPidClaims.ResidenceStreet, it.value.toDataElement()) }
-    pid.residentHouseNumber?.let { addItemToSign(MsoMdocPidClaims.ResidenceHouseNumber, it.toDataElement()) }
+    addItemToSign(MsoMdocPidClaims.Nationality, CBORObjectFactory.toCBORObject(pid.nationalities.map { it.value }))
+    pid.residentAddress?.let { addItemToSign(MsoMdocPidClaims.ResidenceAddress, it) }
+    pid.residentCountry?.let { addItemToSign(MsoMdocPidClaims.ResidenceCountry, it.value) }
+    pid.residentState?.let { addItemToSign(MsoMdocPidClaims.ResidenceState, it.value) }
+    pid.residentCity?.let { addItemToSign(MsoMdocPidClaims.ResidenceCity, it.value) }
+    pid.residentPostalCode?.let { addItemToSign(MsoMdocPidClaims.ResidencePostalCode, it.value) }
+    pid.residentStreet?.let { addItemToSign(MsoMdocPidClaims.ResidenceStreet, it.value) }
+    pid.residentHouseNumber?.let { addItemToSign(MsoMdocPidClaims.ResidenceHouseNumber, it) }
     pid.portrait?.let {
         val value =
             when (it) {
                 is PortraitImage.JPEG -> it.value
                 is PortraitImage.JPEG2000 -> it.value
             }
-        addItemToSign(MsoMdocPidClaims.Portrait, value.toDataElement())
+        addItemToSign(MsoMdocPidClaims.Portrait, value)
     }
-    pid.familyNameBirth?.let { addItemToSign(MsoMdocPidClaims.FamilyNameBirth, it.value.toDataElement()) }
-    pid.givenNameBirth?.let { addItemToSign(MsoMdocPidClaims.GivenNameBirth, it.value.toDataElement()) }
-    pid.sex?.let { addItemToSign(MsoMdocPidClaims.Sex, it.value.toDataElement()) }
-    pid.emailAddress?.let { addItemToSign(MsoMdocPidClaims.EmailAddress, it.toDataElement()) }
-    pid.mobilePhoneNumber?.let { addItemToSign(MsoMdocPidClaims.MobilePhoneNumberAttribute, it.value.toDataElement()) }
+    pid.familyNameBirth?.let { addItemToSign(MsoMdocPidClaims.FamilyNameBirth, it.value) }
+    pid.givenNameBirth?.let { addItemToSign(MsoMdocPidClaims.GivenNameBirth, it.value) }
+    pid.sex?.let { addItemToSign(MsoMdocPidClaims.Sex, it.value) }
+    pid.emailAddress?.let { addItemToSign(MsoMdocPidClaims.EmailAddress, it) }
+    pid.mobilePhoneNumber?.let { addItemToSign(MsoMdocPidClaims.MobilePhoneNumberAttribute, it.value) }
     pid.personalAdministrativeNumber?.let {
         addItemToSign(
             MsoMdocPidClaims.PersonalAdministrativeNumber,
-            it.value.toDataElement(),
+            it.value,
         )
     }
 }
 
-private fun MDocBuilder.addItemsToSign(metaData: PidMetaData) {
-    addItemToSign(MsoMdocPidClaims.ExpiryDate, metaData.expiryDate.toDataElement())
+private fun MdocEAAClaimParameters.addItemsToSign(metaData: PidMetaData) {
+    addItemToSign(MsoMdocPidClaims.ExpiryDate, metaData.expiryDate)
     when (val issuingAuthority = metaData.issuingAuthority) {
         is IssuingAuthority.MemberState -> {
-            addItemToSign(MsoMdocPidClaims.IssuingAuthority, issuingAuthority.code.value.toDataElement())
+            addItemToSign(MsoMdocPidClaims.IssuingAuthority, issuingAuthority.code.value)
         }
 
         is IssuingAuthority.AdministrativeAuthority -> {
-            addItemToSign(MsoMdocPidClaims.IssuingAuthority, issuingAuthority.value.toDataElement())
+            addItemToSign(MsoMdocPidClaims.IssuingAuthority, issuingAuthority.value)
         }
     }
-    addItemToSign(MsoMdocPidClaims.IssuingCountry, metaData.issuingCountry.value.toDataElement())
-    metaData.documentNumber?.let { addItemToSign(MsoMdocPidClaims.DocumentNumber, it.value.toDataElement()) }
-    metaData.issuingJurisdiction?.let { addItemToSign(MsoMdocPidClaims.IssuingJurisdiction, it.toDataElement()) }
-    metaData.issuanceDate?.let { addItemToSign(MsoMdocPidClaims.IssuanceDate, it.toDataElement()) }
+    addItemToSign(MsoMdocPidClaims.IssuingCountry, metaData.issuingCountry.value)
+    metaData.documentNumber?.let { addItemToSign(MsoMdocPidClaims.DocumentNumber, it.value) }
+    metaData.issuingJurisdiction?.let { addItemToSign(MsoMdocPidClaims.IssuingJurisdiction, it) }
+    metaData.issuanceDate?.let { addItemToSign(MsoMdocPidClaims.IssuanceDate, it) }
     metaData.attestationLegalCategory?.let {
-        addItemToSign(
-            MsoMdocPidClaims.AttestationLegalCategory,
-            it.toDataElement(),
-        )
+        addItemToSign(MsoMdocPidClaims.AttestationLegalCategory, it)
     }
-}
-
-private fun MDocBuilder.addItemToSign(
-    claim: ClaimDefinition,
-    value: DataElement,
-) {
-    addItemToSign(MsoMdocPidClaims.nameSpace, claim.name, value)
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/EncodeAttestationAttributesInMdoc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/EncodeAttestationAttributesInMdoc.kt
@@ -16,16 +16,36 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc
 
 import COSE.OneKey
+import cbor.Cbor
+import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
+import eu.europa.ec.eudi.pidissuer.adapter.out.certificate
 import eu.europa.ec.eudi.pidissuer.adapter.out.cryptoProvider
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.AttestationAttributes
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.EncodeAttestationAttributes
+import eu.europa.ec.eudi.pidissuer.adapter.out.x509.dropRootCA
 import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
 import eu.europa.ec.eudi.pidissuer.domain.StatusListToken
 import eu.europa.ec.eudi.pidissuer.domain.TokenStatusListSpec
+import eu.europa.esig.dss.cbades.signature.CBAdESService
+import eu.europa.esig.dss.cbades.signature.CBAdESSignatureParameters
+import eu.europa.esig.dss.cbades.signature.CBAdESSignatureParameters.X5ChainHeaderPlacement
+import eu.europa.esig.dss.enumerations.COSEStructureType
+import eu.europa.esig.dss.enumerations.DigestAlgorithm
+import eu.europa.esig.dss.enumerations.EncryptionAlgorithm
+import eu.europa.esig.dss.enumerations.SignatureLevel
+import eu.europa.esig.dss.enumerations.SignaturePackaging
+import eu.europa.esig.dss.model.InMemoryDocument
+import eu.europa.esig.dss.model.x509.CertificateToken
+import eu.europa.esig.dss.spi.validation.CommonCertificateVerifier
+import eu.europa.esig.dss.token.AbstractSignatureTokenConnection
+import eu.europa.esig.dss.token.DSSPrivateKeyAccessEntry
+import eu.europa.esig.dss.token.DSSPrivateKeyEntry
+import eu.europa.esig.dss.token.KeyStoreSignatureTokenConnection
 import id.walt.mdoc.SimpleCOSECryptoProvider
 import id.walt.mdoc.cose.COSECryptoProvider
+import id.walt.mdoc.cose.COSESign1
 import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.MapElement
 import id.walt.mdoc.dataelement.MapKey
@@ -35,10 +55,17 @@ import id.walt.mdoc.doc.MDocBuilder
 import id.walt.mdoc.mso.DeviceKeyInfo
 import id.walt.mdoc.mso.MSO
 import id.walt.mdoc.mso.ValidityInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.toDeprecatedInstant
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import org.springframework.core.io.DefaultResourceLoader
+import java.security.KeyStore
+import java.security.PrivateKey
 import kotlin.io.encoding.Base64
+import java.time.Instant as JavaInstant
+import java.util.Date as JavaDate
 
 fun <Attr> encodeAttestationAttributesInMdoc(
     docType: MsoDocType,
@@ -72,11 +99,117 @@ private class EncodeAttestationAttributesInMdoc<in Attr>(
         val mdoc =
             MDocBuilder(docType)
                 .apply { usage(credential) }
-                .sign(validityInfo, deviceKeyInfo, statusListToken, issuerCryptoProvider, issuerSigningKey.key.keyID)
+                .sign(validityInfo, deviceKeyInfo, statusListToken, issuerSigningKey)
         val encoded = base64UrlSafeNoPadding.encode(mdoc.issuerSigned.toMapElement().toCBOR())
         return JsonPrimitive(encoded)
     }
 }
+
+private suspend fun MDocBuilder.sign(
+    validityInfo: ValidityInfo,
+    deviceKeyInfo: DeviceKeyInfo,
+    statusListToken: StatusListToken?,
+    signingKey: IssuerSigningKey,
+): MDoc {
+    val service = CBAdESService(CommonCertificateVerifier())
+    val signatureParameters =
+        CBAdESSignatureParameters()
+            .apply {
+                signatureLevel = SignatureLevel.CB_AdES_BASELINE_B
+                signaturePackaging = SignaturePackaging.ENVELOPING
+
+                coseStructureType = COSEStructureType.COSE_SIGN1
+                isTagged = true
+
+                bLevel().signingDate = JavaDate.from(JavaInstant.ofEpochSecond(validityInfo.signed.value.epochSeconds))
+
+                signingCertificate = CertificateToken(signingKey.certificate)
+                certificateChain =
+                    signingKey.key
+                        .parsedX509CertChain
+                        .dropRootCA()
+                        .map { CertificateToken(it) }
+                isIncludeCertificateChain = true
+                x5ChainHeaderPlacement = X5ChainHeaderPlacement.protectedHeader
+                isIncludeCertificateChainThumbprints = true
+
+                digestAlgorithm =
+                    when (signingKey.key.curve) {
+                        Curve.P_256 -> DigestAlgorithm.SHA256
+                        Curve.P_384 -> DigestAlgorithm.SHA384
+                        Curve.P_521 -> DigestAlgorithm.SHA512
+                        else -> error("Unsupported ECKey Curve '${signingKey.key.curve}'")
+                    }
+            }
+    val payload = createIssuerAuthPayload(deviceKeyInfo, validityInfo, statusListToken)
+    val unsignedDocument = InMemoryDocument(payload.toEncodedCBORElement().toCBOR())
+    val unsignedData = service.getDataToSign(unsignedDocument, signatureParameters)
+
+    val privateKey = signingKey.toDSSPrivateKeyAccessEntry(includeRootCA = false)
+    val signatureTokenConnection = SimpleSignatureTokenConnection(privateKey)
+
+    val signatureValue =
+        withContext(Dispatchers.IO) {
+            signatureTokenConnection.sign(unsignedData, signatureParameters.digestAlgorithm, privateKey)
+        }
+    val signedDocument = service.signDocument(unsignedDocument, signatureParameters, signatureValue)
+
+    val serializedIssuerAuth = signedDocument.openStream().use { it.readBytes() }
+    val issuerAuth = Cbor.decodeFromByteArray(COSESign1.serializer(), serializedIssuerAuth)
+
+    return build(issuerAuth, null)
+}
+
+private fun MDocBuilder.createIssuerAuthPayload(
+    deviceKeyInfo: DeviceKeyInfo,
+    validityInfo: ValidityInfo,
+    statusListToken: StatusListToken?,
+): MapElement {
+    val mso = MSO.createFor(nameSpacesMap, deviceKeyInfo, docType, validityInfo)
+    return if (null != statusListToken) {
+        buildMap {
+            mso
+                .toMapElement()
+                .value.entries
+                .forEach { put(it.key, it.value) }
+            put(MapKey(TokenStatusListSpec.STATUS), statusListToken.toMsoStatus())
+        }.toDataElement()
+    } else {
+        mso.toMapElement()
+    }
+}
+
+private class SimpleSignatureTokenConnection(
+    private val key: DSSPrivateKeyEntry,
+) : AbstractSignatureTokenConnection() {
+    override fun close() {
+        // no-op
+    }
+
+    override fun getKeys(): List<DSSPrivateKeyEntry> = listOf(key)
+}
+
+private fun IssuerSigningKey.toDSSPrivateKeyAccessEntry(includeRootCA: Boolean): DSSPrivateKeyAccessEntry =
+    object : DSSPrivateKeyAccessEntry {
+        override fun getPrivateKey(): PrivateKey = this@toDSSPrivateKeyAccessEntry.key.toECPrivateKey()
+
+        override fun getCertificate(): CertificateToken = CertificateToken(this@toDSSPrivateKeyAccessEntry.certificate)
+
+        override fun getCertificateChain(): Array<CertificateToken> =
+            this@toDSSPrivateKeyAccessEntry
+                .key
+                .let {
+                    if (includeRootCA) {
+                        it.parsedX509CertChain
+                    } else {
+                        it.parsedX509CertChain.dropRootCA()
+                    }
+                }.map { CertificateToken(it) }
+                .toTypedArray()
+
+        override fun getEncryptionAlgorithm(): EncryptionAlgorithm =
+            EncryptionAlgorithm.forKey(this@toDSSPrivateKeyAccessEntry.key.toECPrivateKey())
+    }
 
 private fun deviceKeyInfo(deviceKey: ECKey): DeviceKeyInfo {
     val key = OneKey(deviceKey.toECPublicKey(), null)
@@ -99,19 +232,7 @@ private fun MDocBuilder.sign(
     cryptoProvider: COSECryptoProvider,
     keyID: String? = null,
 ): MDoc {
-    val mso = MSO.createFor(nameSpacesMap, deviceKeyInfo, docType, validityInfo)
-    val payload =
-        if (null != statusListToken) {
-            buildMap {
-                mso
-                    .toMapElement()
-                    .value.entries
-                    .forEach { put(it.key, it.value) }
-                put(MapKey(TokenStatusListSpec.STATUS), statusListToken.toMsoStatus())
-            }.toDataElement()
-        } else {
-            mso.toMapElement()
-        }
+    val payload = createIssuerAuthPayload(deviceKeyInfo, validityInfo, statusListToken)
     val issuerAuth = cryptoProvider.sign1(payload.toEncodedCBORElement().toCBOR(), null, null, keyID)
     return build(issuerAuth)
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/EncodeAttestationAttributesInMdoc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/EncodeAttestationAttributesInMdoc.kt
@@ -15,169 +15,114 @@
  */
 package eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc
 
-import COSE.OneKey
-import cbor.Cbor
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.IssuerSigningKey
 import eu.europa.ec.eudi.pidissuer.adapter.out.certificate
-import eu.europa.ec.eudi.pidissuer.adapter.out.cryptoProvider
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.AttestationAttributes
 import eu.europa.ec.eudi.pidissuer.adapter.out.format.EncodeAttestationAttributes
 import eu.europa.ec.eudi.pidissuer.adapter.out.x509.dropRootCA
 import eu.europa.ec.eudi.pidissuer.domain.MsoDocType
-import eu.europa.ec.eudi.pidissuer.domain.StatusListToken
-import eu.europa.ec.eudi.pidissuer.domain.TokenStatusListSpec
-import eu.europa.esig.dss.cbades.signature.CBAdESService
 import eu.europa.esig.dss.cbades.signature.CBAdESSignatureParameters
 import eu.europa.esig.dss.cbades.signature.CBAdESSignatureParameters.X5ChainHeaderPlacement
-import eu.europa.esig.dss.enumerations.COSEStructureType
-import eu.europa.esig.dss.enumerations.DigestAlgorithm
-import eu.europa.esig.dss.enumerations.EncryptionAlgorithm
-import eu.europa.esig.dss.enumerations.SignatureLevel
-import eu.europa.esig.dss.enumerations.SignaturePackaging
-import eu.europa.esig.dss.model.InMemoryDocument
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAClaimParameters
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAPayloadParameters
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAService
+import eu.europa.esig.dss.enumerations.*
 import eu.europa.esig.dss.model.x509.CertificateToken
 import eu.europa.esig.dss.spi.validation.CommonCertificateVerifier
 import eu.europa.esig.dss.token.AbstractSignatureTokenConnection
 import eu.europa.esig.dss.token.DSSPrivateKeyAccessEntry
 import eu.europa.esig.dss.token.DSSPrivateKeyEntry
-import eu.europa.esig.dss.token.KeyStoreSignatureTokenConnection
-import id.walt.mdoc.SimpleCOSECryptoProvider
-import id.walt.mdoc.cose.COSECryptoProvider
-import id.walt.mdoc.cose.COSESign1
-import id.walt.mdoc.dataelement.DataElement
-import id.walt.mdoc.dataelement.MapElement
-import id.walt.mdoc.dataelement.MapKey
-import id.walt.mdoc.dataelement.toDataElement
-import id.walt.mdoc.doc.MDoc
-import id.walt.mdoc.doc.MDocBuilder
-import id.walt.mdoc.mso.DeviceKeyInfo
-import id.walt.mdoc.mso.MSO
-import id.walt.mdoc.mso.ValidityInfo
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.datetime.toDeprecatedInstant
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
-import org.springframework.core.io.DefaultResourceLoader
-import java.security.KeyStore
 import java.security.PrivateKey
 import kotlin.io.encoding.Base64
+import kotlin.time.Instant
 import java.time.Instant as JavaInstant
 import java.util.Date as JavaDate
 
-fun <Attr> encodeAttestationAttributesInMdoc(
-    docType: MsoDocType,
-    issuerSigningKey: IssuerSigningKey,
-    usage: MDocBuilder.(Attr) -> Unit = {},
-): EncodeAttestationAttributes<Attr> = EncodeAttestationAttributesInMdoc(issuerSigningKey, docType, usage)
-
 private val base64UrlSafeNoPadding = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
 
-private class EncodeAttestationAttributesInMdoc<in Attr>(
-    private val issuerSigningKey: IssuerSigningKey,
-    private val docType: MsoDocType,
-    private val usage: MDocBuilder.(Attr) -> Unit,
-) : EncodeAttestationAttributes<Attr> {
-    private val issuerCryptoProvider: SimpleCOSECryptoProvider by lazy {
-        issuerSigningKey.cryptoProvider(includeRootCA = false)
-    }
+@Suppress("FunctionName")
+fun <Attr> EncodeAttestationAttributesInMdoc(
+    issuerSigningKey: IssuerSigningKey,
+    docType: MsoDocType,
+    usage: MdocEAAClaimParameters.(Attr) -> Unit,
+): EncodeAttestationAttributes<Attr> =
+    object : EncodeAttestationAttributes<Attr> {
+        override suspend fun invoke(attestationAttributes: AttestationAttributes<Attr>): JsonElement {
+            val (credential, issuedAt, expiresAt, _, deviceKey, statusListToken) = attestationAttributes
 
-    override suspend fun invoke(attestationAttributes: AttestationAttributes<Attr>): JsonElement {
-        val (credential, issuedAt, expiresAt, _, deviceKey, statusListToken) = attestationAttributes
-        require(deviceKey is ECKey) { "deviceKey must be ECKey" }
-        require(expiresAt >= issuedAt) { "expiresAt must greater or equal to issuedAt" }
-        val validityInfo =
-            ValidityInfo(
-                signed = issuedAt.dropFractionOfSeconds().toDeprecatedInstant(),
-                validFrom = issuedAt.dropFractionOfSeconds().toDeprecatedInstant(),
-                validUntil = expiresAt.dropFractionOfSeconds().toDeprecatedInstant(),
-                expectedUpdate = null,
-            )
-        val deviceKeyInfo = deviceKeyInfo(deviceKey)
-        val mdoc =
-            MDocBuilder(docType)
-                .apply { usage(credential) }
-                .sign(validityInfo, deviceKeyInfo, statusListToken, issuerSigningKey)
-        val encoded = base64UrlSafeNoPadding.encode(mdoc.issuerSigned.toMapElement().toCBOR())
-        return JsonPrimitive(encoded)
-    }
-}
-
-private suspend fun MDocBuilder.sign(
-    validityInfo: ValidityInfo,
-    deviceKeyInfo: DeviceKeyInfo,
-    statusListToken: StatusListToken?,
-    signingKey: IssuerSigningKey,
-): MDoc {
-    val service = CBAdESService(CommonCertificateVerifier())
-    val signatureParameters =
-        CBAdESSignatureParameters()
-            .apply {
-                signatureLevel = SignatureLevel.CB_AdES_BASELINE_B
-                signaturePackaging = SignaturePackaging.ENVELOPING
-
-                coseStructureType = COSEStructureType.COSE_SIGN1
-                isTagged = true
-
-                bLevel().signingDate = JavaDate.from(JavaInstant.ofEpochSecond(validityInfo.signed.value.epochSeconds))
-
-                signingCertificate = CertificateToken(signingKey.certificate)
-                certificateChain =
-                    signingKey.key
-                        .parsedX509CertChain
-                        .dropRootCA()
-                        .map { CertificateToken(it) }
-                isIncludeCertificateChain = true
-                x5ChainHeaderPlacement = X5ChainHeaderPlacement.protectedHeader
-                isIncludeCertificateChainThumbprints = true
-
-                digestAlgorithm =
-                    when (signingKey.key.curve) {
-                        Curve.P_256 -> DigestAlgorithm.SHA256
-                        Curve.P_384 -> DigestAlgorithm.SHA384
-                        Curve.P_521 -> DigestAlgorithm.SHA512
-                        else -> error("Unsupported ECKey Curve '${signingKey.key.curve}'")
+            val mso =
+                MdocEAAPayloadParameters()
+                    .apply {
+                        this.docType = docType
+                        signed = JavaDate.from(JavaInstant.ofEpochSecond(issuedAt.epochSeconds))
+                        validFrom = JavaDate.from(JavaInstant.ofEpochSecond(issuedAt.epochSeconds))
+                        validUntil = JavaDate.from(JavaInstant.ofEpochSecond(expiresAt.epochSeconds))
+                        expectedUpdate = null
+                        if (null != deviceKey) {
+                            this.deviceKey = deviceKey.toECKey().toECPublicKey()
+                        }
+                        if (null != statusListToken) {
+                            setStatusList(statusListToken.index.toInt(), statusListToken.statusList.toString())
+                        }
+                        selectivelyDisclosable().usage(credential)
                     }
-            }
-    val payload = createIssuerAuthPayload(deviceKeyInfo, validityInfo, statusListToken)
-    val unsignedDocument = InMemoryDocument(payload.toEncodedCBORElement().toCBOR())
-    val unsignedData = service.getDataToSign(unsignedDocument, signatureParameters)
 
-    val privateKey = signingKey.toDSSPrivateKeyAccessEntry(includeRootCA = false)
-    val signatureTokenConnection = SimpleSignatureTokenConnection(privateKey)
+            val signatureParameters = signatureParameters(issuedAt)
+            val service = MdocEAAService(CommonCertificateVerifier())
 
-    val signatureValue =
-        withContext(Dispatchers.IO) {
-            signatureTokenConnection.sign(unsignedData, signatureParameters.digestAlgorithm, privateKey)
+            val issuerAuthPayload = service.getDataToBeSigned(mso, signatureParameters)
+
+            val signingKey = issuerSigningKey.toDSSPrivateKeyAccessEntry()
+            val signer = SimpleSignatureTokenConnection(signingKey)
+            val signature = signer.sign(issuerAuthPayload, signatureParameters.digestAlgorithm, signingKey)
+
+            val issuerAuth = service.signEAA(mso, signatureParameters, signature)
+
+            val issuerSigned = service.createIssuerSigned(issuerAuth, service.getDisclosures(mso))
+            val serializedIssuerSigned = issuerSigned.openStream().use { it.readBytes() }
+            return JsonPrimitive(base64UrlSafeNoPadding.encode(serializedIssuerSigned))
         }
-    val signedDocument = service.signDocument(unsignedDocument, signatureParameters, signatureValue)
 
-    val serializedIssuerAuth = signedDocument.openStream().use { it.readBytes() }
-    val issuerAuth = Cbor.decodeFromByteArray(COSESign1.serializer(), serializedIssuerAuth)
+        private fun signatureParameters(signingDate: Instant): CBAdESSignatureParameters =
+            CBAdESSignatureParameters()
+                .apply {
+                    signatureLevel = SignatureLevel.CB_AdES_BASELINE_B
+                    signaturePackaging = SignaturePackaging.ENVELOPING
 
-    return build(issuerAuth, null)
-}
+                    coseStructureType = COSEStructureType.COSE_SIGN1
+                    isTagged = false
 
-private fun MDocBuilder.createIssuerAuthPayload(
-    deviceKeyInfo: DeviceKeyInfo,
-    validityInfo: ValidityInfo,
-    statusListToken: StatusListToken?,
-): MapElement {
-    val mso = MSO.createFor(nameSpacesMap, deviceKeyInfo, docType, validityInfo)
-    return if (null != statusListToken) {
-        buildMap {
-            mso
-                .toMapElement()
-                .value.entries
-                .forEach { put(it.key, it.value) }
-            put(MapKey(TokenStatusListSpec.STATUS), statusListToken.toMsoStatus())
-        }.toDataElement()
-    } else {
-        mso.toMapElement()
+                    bLevel().signingDate = JavaDate.from(JavaInstant.ofEpochSecond(signingDate.epochSeconds))
+
+                    signingCertificate = CertificateToken(issuerSigningKey.certificate)
+                    certificateChain =
+                        issuerSigningKey.key
+                            .parsedX509CertChain
+                            .dropRootCA()
+                            .map { CertificateToken(it) }
+                    isIncludeCertificateChain = true
+                    x5ChainHeaderPlacement = X5ChainHeaderPlacement.unprotectedHeader
+                    isIncludeCertificateChainThumbprints = true
+                    if (null != issuerSigningKey.key.keyID) {
+                        isIncludeKeyIdentifier = true
+                        keyIdentifier = issuerSigningKey.key.keyID.encodeToByteArray()
+                    } else {
+                        isIncludeKeyIdentifier = false
+                    }
+                    signingCertificateDigestMethod = DigestAlgorithm.SHA256
+
+                    digestAlgorithm =
+                        when (issuerSigningKey.key.curve) {
+                            Curve.P_256 -> DigestAlgorithm.SHA256
+                            Curve.P_384 -> DigestAlgorithm.SHA384
+                            Curve.P_521 -> DigestAlgorithm.SHA512
+                            else -> error("Unsupported ECKey Curve '${issuerSigningKey.key.curve}'")
+                        }
+                }
     }
-}
 
 private class SimpleSignatureTokenConnection(
     private val key: DSSPrivateKeyEntry,
@@ -189,7 +134,7 @@ private class SimpleSignatureTokenConnection(
     override fun getKeys(): List<DSSPrivateKeyEntry> = listOf(key)
 }
 
-private fun IssuerSigningKey.toDSSPrivateKeyAccessEntry(includeRootCA: Boolean): DSSPrivateKeyAccessEntry =
+private fun IssuerSigningKey.toDSSPrivateKeyAccessEntry(): DSSPrivateKeyAccessEntry =
     object : DSSPrivateKeyAccessEntry {
         override fun getPrivateKey(): PrivateKey = this@toDSSPrivateKeyAccessEntry.key.toECPrivateKey()
 
@@ -198,57 +143,11 @@ private fun IssuerSigningKey.toDSSPrivateKeyAccessEntry(includeRootCA: Boolean):
         override fun getCertificateChain(): Array<CertificateToken> =
             this@toDSSPrivateKeyAccessEntry
                 .key
-                .let {
-                    if (includeRootCA) {
-                        it.parsedX509CertChain
-                    } else {
-                        it.parsedX509CertChain.dropRootCA()
-                    }
-                }.map { CertificateToken(it) }
+                .parsedX509CertChain
+                .dropRootCA()
+                .map { CertificateToken(it) }
                 .toTypedArray()
 
         override fun getEncryptionAlgorithm(): EncryptionAlgorithm =
             EncryptionAlgorithm.forKey(this@toDSSPrivateKeyAccessEntry.key.toECPrivateKey())
     }
-
-private fun deviceKeyInfo(deviceKey: ECKey): DeviceKeyInfo {
-    val key = OneKey(deviceKey.toECPublicKey(), null)
-    val deviceKeyDataElement: MapElement = DataElement.Companion.fromCBOR(key.AsCBOR().EncodeToBytes())
-    return DeviceKeyInfo(deviceKeyDataElement, null, null)
-}
-
-/**
- * Build and sign the mdoc document
- * @param validityInfo Validity information of this issued document
- * @param deviceKeyInfo Info of device key, to which this document is bound (holder key)
- * @param statusListToken Status List Token to include in the document
- * @param cryptoProvider COSE crypto provider impl to use for signing this document
- * @param keyID ID of the key to use for signing, if required by crypto provider
- */
-private fun MDocBuilder.sign(
-    validityInfo: ValidityInfo,
-    deviceKeyInfo: DeviceKeyInfo,
-    statusListToken: StatusListToken?,
-    cryptoProvider: COSECryptoProvider,
-    keyID: String? = null,
-): MDoc {
-    val payload = createIssuerAuthPayload(deviceKeyInfo, validityInfo, statusListToken)
-    val issuerAuth = cryptoProvider.sign1(payload.toEncodedCBORElement().toCBOR(), null, null, keyID)
-    return build(issuerAuth)
-}
-
-/**
- * Converts this [StatusListToken] to a `Status` Map Element as defined in
- * [12.3.4 Signing method and structure for MSO](https://github.com/ISOWG10/ISO-18013/blob/main/Working%20Documents/Working%20Draft%20ISO_IEC_18013-5_second-edition_CD_ballot_resolution_v3.pdf)
- */
-private fun StatusListToken.toMsoStatus(): MapElement {
-    fun StatusListToken.toDE(): MapElement =
-        buildMap {
-            put(MapKey(TokenStatusListSpec.IDX), index.toDataElement())
-            put(MapKey(TokenStatusListSpec.URI), statusList.toString().toDataElement())
-        }.toDataElement()
-
-    return buildMap {
-        put(MapKey(TokenStatusListSpec.STATUS_LIST), toDE())
-    }.toDataElement()
-}

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/LocalDateExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/LocalDateExtensions.kt
@@ -17,13 +17,11 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc
 
 import eu.europa.esig.dss.cbades.cbor.CBORObject
 import eu.europa.esig.dss.cbades.cbor.CBORObjectFactory
-import kotlin.time.Instant
+import kotlinx.datetime.LocalDate
 
-fun Instant.dropFractionOfSeconds(): Instant = Instant.fromEpochSeconds(epochSeconds, 0L)
-
-fun Instant.toTDate(): CBORObject {
+fun LocalDate.toFullDate(): CBORObject {
     val value = toString()
     val cborObject = CBORObjectFactory.toCBORObject(value)
-    cborObject.setTag(0L)
+    cborObject.setTag(1004L)
     return cborObject
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/MdocEAAClaimParametersExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/format/mdoc/MdocEAAClaimParametersExtensions.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.pidissuer.adapter.out.format.mdoc
+
+import eu.europa.ec.eudi.pidissuer.domain.ClaimDefinition
+import eu.europa.ec.eudi.pidissuer.domain.attributeName
+import eu.europa.ec.eudi.pidissuer.domain.nameSpace
+import eu.europa.esig.dss.cbades.cbor.CBORObject
+import eu.europa.esig.dss.cbades.cbor.CBORObjectFactory
+import eu.europa.esig.dss.eaa.mdoc.creation.MdocEAAClaimParameters
+import eu.europa.esig.dss.eaa.mdoc.creation.claim.MdocEAAClaim
+import kotlinx.datetime.LocalDate
+import kotlin.time.Instant
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: String,
+) {
+    addItemToSign(claim, CBORObjectFactory.toCBORObject(value))
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: UInt,
+) {
+    addItemToSign(claim, CBORObjectFactory.toCBORObject(value.toInt()))
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: ByteArray,
+) {
+    addItemToSign(claim, CBORObjectFactory.toCBORObject(value))
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: LocalDate,
+) {
+    addItemToSign(claim, value.toFullDate())
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: Instant,
+) {
+    addItemToSign(claim, value.toTDate())
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: Boolean,
+) {
+    addItemToSign(claim, CBORObjectFactory.toCBORObject(value))
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: CBORObject,
+) {
+    otherClaims.add(MdocEAAClaim.create(claim.nameSpace, claim.attributeName, value))
+}
+
+fun MdocEAAClaimParameters.addItemToSign(
+    claim: ClaimDefinition,
+    value: Collection<CBORObject>,
+) {
+    otherClaims.add(MdocEAAClaim.create(claim.nameSpace, claim.attributeName, CBORObjectFactory.toCBORObject(value)))
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/MsoMdocProfile.kt
@@ -44,6 +44,18 @@ operator fun ClaimDefinition.Companion.invoke(
     display: Display = emptyMap(),
 ): ClaimDefinition = ClaimDefinition(ClaimPath(nameSpace, attributeName), mandatory, display)
 
+val ClaimDefinition.nameSpace: MsoNameSpace
+    get() {
+        check(path.isMsoMDoc())
+        return (path.value.first() as ClaimPathElement.Claim).name
+    }
+
+val ClaimDefinition.attributeName: String
+    get() {
+        check(path.isMsoMDoc())
+        return (path.value.last() as ClaimPathElement.Claim).name
+    }
+
 /**
  * @param docType string identifying the credential type as defined in ISO.18013-5.
  */


### PR DESCRIPTION
This PR:

1. Replaces walt.id MDocs v1 library with DSS EAA MDoc. 
Even though `MdocEAAClaimParameters` models common mDL/PID attributes, it also contains `otherClaims` which is a `List<MdocEAAClaim>`, and can be used for all other NameSpaces/Attributes.
MSO MDoc encoders in pid-issuer have been updated to use `otherClaims`, and do not depend on any common mDL/PID attributes.
2. Adds support for signing MSO MDoc Credentials using CB-AdES.

Closes #624
