### PR TITLE
Verify the `typ` of a WRP Registration Certificate

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/CredentialIssuerMetaData.kt
@@ -20,6 +20,7 @@ import arrow.core.NonEmptySet
 import arrow.core.toNonEmptySetOrNull
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWSVerifier
 import com.nimbusds.jose.crypto.ECDSAVerifier
@@ -316,6 +317,12 @@ value class Wrprc private constructor(
     companion object {
         fun tryParse(registrationCertificate: String): Wrprc {
             val jwt = SignedJWT.parse(registrationCertificate)
+
+            val type = JOSEObjectType(ETSI119475.WALLET_RELYING_PARTY_REGISTRATION_CERTIFICATE_TYPE)
+            require(type == jwt.header.type) {
+                "Incorrect WRPRC 'typ'. Expected ${type.type}, but found ${jwt.header.type?.type} instead."
+            }
+
             val x5c = jwt.header.x509CertChain
             require(!x5c.isNullOrEmpty()) { "WRPRC must contain a valid certificate chain" }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/domain/Specs.kt
@@ -89,3 +89,12 @@ object ETSI119472Part3 {
     const val ISSUER_INFO_DATA: String = "data"
     const val ISSUER_INFO_FORMAT_REGISTRATION_CERT: String = "registration_cert"
 }
+
+/**
+ * [Electronic Signatures and Trust Infrastructures (ESI);
+ * Relying party attributes supporting EUDI Wallet user's authorization decisions](https://www.etsi.org/deliver/etsi_ts/119400_119499/119475/01.02.01_60/ts_119475v010201p.pdf)
+ */
+object ETSI119475 {
+    // JWT Type
+    const val WALLET_RELYING_PARTY_REGISTRATION_CERTIFICATE_TYPE = "rc-wrp+jwt"
+}


### PR DESCRIPTION
This PR add a missing WRP Registration Certificate check.

We now ensure that `typ` is set to `rc-wrp+jwt` as defined by ETSI TS 119 475.