### PR TITLE
Use the correct `UriSpec.uri` function to avoid double encoding

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/attestation/pid/GetPidDataFromKeyCloak.kt
@@ -19,6 +19,7 @@ import arrow.core.nonEmptyListOf
 import arrow.core.raise.Raise
 import arrow.core.raise.context.ensure
 import com.eygraber.uri.Url
+import com.eygraber.uri.toURI
 import com.nimbusds.oauth2.sdk.token.AccessToken
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils
 import eu.europa.ec.eudi.pidissuer.adapter.out.attestation.OidcAssurancePlaceOfBirth
@@ -190,7 +191,7 @@ class GetPidDataFromKeyCloak(
         val users =
             webClient
                 .get()
-                .uri(url.toString())
+                .uri(url.toURI())
                 .accept(MediaType.APPLICATION_JSON)
                 .headers {
                     it[HttpHeaders.AUTHORIZATION] = accessToken.toAuthorizationHeader()
@@ -217,7 +218,7 @@ class GetPidDataFromKeyCloak(
         val response =
             webClient
                 .post()
-                .uri(tokenEndpoint.toString())
+                .uri(tokenEndpoint.toURI())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
                 .body(

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/status/GenerateStatusListTokenWithExternalService.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/status/GenerateStatusListTokenWithExternalService.kt
@@ -20,6 +20,7 @@ import arrow.core.raise.context.Raise
 import arrow.core.raise.context.raise
 import com.eygraber.uri.Uri
 import com.eygraber.uri.Url
+import com.eygraber.uri.toURI
 import eu.europa.ec.eudi.pidissuer.domain.StatusListToken
 import eu.europa.ec.eudi.pidissuer.domain.toZonedDateTime
 import eu.europa.ec.eudi.pidissuer.port.out.status.AllocateStatus
@@ -57,7 +58,7 @@ class GenerateStatusListTokenWithExternalService(
         val statusTokens =
             webClient
                 .post()
-                .uri(serviceUrl.toString())
+                .uri(serviceUrl.toURI())
                 .headers {
                     it.contentType = MediaType.APPLICATION_FORM_URLENCODED
                     it.accept = listOf(MediaType.APPLICATION_JSON)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/status/MarkStatusAsRevokedWithExternalService.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/status/MarkStatusAsRevokedWithExternalService.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.pidissuer.adapter.out.status
 import arrow.core.raise.Raise
 import arrow.core.raise.context.ensure
 import com.eygraber.uri.Url
+import com.eygraber.uri.toURI
 import eu.europa.ec.eudi.pidissuer.domain.StatusListToken
 import eu.europa.ec.eudi.pidissuer.port.out.status.MarkStatusAsRevoked
 import org.springframework.util.LinkedMultiValueMap
@@ -34,7 +35,7 @@ internal class MarkStatusAsRevokedWithExternalService(
     override suspend fun invoke(status: StatusListToken) {
         webClient
             .post()
-            .uri(serviceUrl.toString())
+            .uri(serviceUrl.toURI())
             .headers { it.set(API_KEY_HEADER, apiKey) }
             .body(
                 BodyInserters.fromFormData(

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/IssuerUiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/IssuerUiTest.kt
@@ -39,7 +39,7 @@ class IssuerUiTest {
         runTest {
             client()
                 .get()
-                .uri(IssuerUi.GENERATE_CREDENTIALS_OFFER)
+                .uri { it.path(IssuerUi.GENERATE_CREDENTIALS_OFFER).build() }
                 .exchange()
                 .expectStatus()
                 .isOk

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/MetaDataApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/MetaDataApiTest.kt
@@ -43,7 +43,7 @@ internal class MetaDataApiTest {
         runTest {
             client()
                 .get()
-                .uri(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER)
+                .uri { it.path(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER).build() }
                 .accept(MediaType.ALL)
                 .exchange()
                 .expectNoContentSecurityPolicy()
@@ -59,7 +59,7 @@ internal class MetaDataApiTest {
         runTest {
             client()
                 .get()
-                .uri(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER)
+                .uri { it.path(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER).build() }
                 .exchange()
                 .expectNoContentSecurityPolicy()
                 .expectStatus()
@@ -74,7 +74,7 @@ internal class MetaDataApiTest {
         runTest {
             client()
                 .get()
-                .uri(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER)
+                .uri { it.path(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER).build() }
                 .accept(applicationJwt)
                 .exchange()
                 .expectNoContentSecurityPolicy()
@@ -90,7 +90,7 @@ internal class MetaDataApiTest {
         runTest {
             client()
                 .get()
-                .uri(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER)
+                .uri { it.path(MetaDataApi.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER).build() }
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectNoContentSecurityPolicy()

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/input/web/WalletApiTest.kt
@@ -192,7 +192,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
         runTest {
             client()
                 .post()
-                .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(requestByCredentialConfigurationId())
                 .accept(MediaType.APPLICATION_JSON)
@@ -215,7 +215,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -247,7 +247,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
             client()
                 .mutateWith(mockAuthentication(authentication))
                 .post()
-                .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(
                     requestByCredentialConfigurationId(
@@ -275,7 +275,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -310,7 +310,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId())
                     .accept(MediaType.APPLICATION_JSON)
@@ -344,7 +344,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -381,7 +381,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -422,7 +422,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -453,7 +453,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -486,7 +486,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -513,7 +513,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         CredentialRequestTO(
@@ -544,7 +544,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsNotRequiredTest : BaseW
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestByCredentialConfigurationId(proofs = proofs)
@@ -607,7 +607,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -648,7 +648,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -697,7 +697,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -735,7 +735,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -774,7 +774,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -812,7 +812,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -852,7 +852,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -889,7 +889,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -930,7 +930,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -963,7 +963,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = keyAttestationJwt.toAttestationProofs()))
                     .accept(MediaType.APPLICATION_JSON)
@@ -1009,7 +1009,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestByCredentialConfigurationId(proofs = proofs)
@@ -1053,7 +1053,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -1093,7 +1093,7 @@ internal class WalletApiEncryptionOptionalKeyAttestationsRequiredTest : BaseWall
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(requestByCredentialConfigurationId(proofs = proofs))
                     .accept(MediaType.APPLICATION_JSON)
@@ -1150,7 +1150,7 @@ internal class WalletApiResponseEncryptionRequiredTest : BaseWalletApiTest() {
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestByCredentialConfigurationId(proofs = proofs)
@@ -1193,7 +1193,7 @@ internal class WalletApiResponseEncryptionRequiredTest : BaseWalletApiTest() {
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -1251,7 +1251,7 @@ internal class WalletApiResponseEncryptionRequiredTest : BaseWalletApiTest() {
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -1305,7 +1305,7 @@ internal class WalletApiResponseEncryptionRequiredTest : BaseWalletApiTest() {
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         requestByCredentialConfigurationId(
@@ -1345,7 +1345,7 @@ internal class WalletApiDeferredIssuanceResponseEncryptionOptionalTest : BaseWal
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(
                         requestDeferredByCredentialIdentifier(
@@ -1367,7 +1367,7 @@ internal class WalletApiDeferredIssuanceResponseEncryptionOptionalTest : BaseWal
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.DEFERRED_ENDPOINT)
+                    .uri { it.path(WalletApi.DEFERRED_ENDPOINT).build() }
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(DeferredCredentialRequestTO(transactionId))
                     .accept(MediaType.APPLICATION_JSON)
@@ -1406,7 +1406,7 @@ internal class WalletApiDeferredIssuanceResponseEncryptionRequiredTest : BaseWal
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.CREDENTIAL_ENDPOINT)
+                    .uri { it.path(WalletApi.CREDENTIAL_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         requestDeferredByCredentialIdentifier(
@@ -1445,7 +1445,7 @@ internal class WalletApiDeferredIssuanceResponseEncryptionRequiredTest : BaseWal
                 client()
                     .mutateWith(mockAuthentication(authentication))
                     .post()
-                    .uri(WalletApi.DEFERRED_ENDPOINT)
+                    .uri { it.path(WalletApi.DEFERRED_ENDPOINT).build() }
                     .contentType(MediaType.parseMediaType("application/jwt"))
                     .bodyValue(
                         DeferredCredentialRequestTO(


### PR DESCRIPTION
`UriSpec.uri` contains multiple overloaded version.

The versions that accept a String template, eventually encode UTF-8 and special characters.

In cases where we have a pre-constructed Uri that contains encoded characters, using the above version of `UriSpec.uri` causes these characters to be encoded twice.
To avoid this issue, use `UriSpec.uri` which accepts a `java.net.URI` instead.

This PR also updates test cases to make use of `UriSpec.uri` which accepts `Function<UriBuilder, URI>` instead.